### PR TITLE
uploader module: Use api.Error instead of Exception

### DIFF
--- a/cloudinary/uploader.py
+++ b/cloudinary/uploader.py
@@ -1,6 +1,7 @@
 # Copyright Cloudinary
 import cloudinary
 from cloudinary import utils
+from cloudinary.api import Error
 import json
 import re
 from poster.encode import multipart_encode
@@ -202,7 +203,7 @@ def call_api(action, params, **options):
         response = urllib2.urlopen(request).read()
     except urllib2.HTTPError, e:
         if not e.code in [200, 400, 500]:
-            raise Exception("Server returned unexpected status code - %d - %s" % (e.code, e.read()))
+            raise Error("Server returned unexpected status code - %d - %s" % (e.code, e.read()))
         code = e.code
         response = e.read()
 
@@ -210,13 +211,13 @@ def call_api(action, params, **options):
         result = json.loads(response)
     except Exception, e:
         # Error is parsing json
-        raise Exception("Error parsing server response (%d) - %s. Got - %s", code, response, e)
+        raise Error("Error parsing server response (%d) - %s. Got - %s", code, response, e)
 
     if "error" in result:
         if return_error:
             result["error"]["http_code"] = response.code
         else:
-            raise Exception(result["error"]["message"])
+            raise Error(result["error"]["message"])
 
     return result
 

--- a/tests/uploader_test.py
+++ b/tests/uploader_test.py
@@ -49,7 +49,7 @@ class TestUploader(unittest.TestCase):
         uploader.rename(result["public_id"], result["public_id"]+"2")
         self.assertIsNotNone(api.resource(result["public_id"]+"2"))
         result2 = uploader.upload("tests/favicon.ico")
-        self.assertRaises(Exception, uploader.rename, (result2["public_id"], result["public_id"]+"2"))
+        self.assertRaises(api.Error, uploader.rename, (result2["public_id"], result["public_id"]+"2"))
         uploader.rename(result2["public_id"], result["public_id"]+"2", overwrite=True)
         self.assertEqual(api.resource(result["public_id"]+"2")["format"], "ico")
 


### PR DESCRIPTION
- This is to let the callers know the Exception came
  from this library.
