### PR TITLE
Use index of version_info tuple rather than named (added in 2.7)

### DIFF
--- a/cloudinary/compat.py
+++ b/cloudinary/compat.py
@@ -1,7 +1,7 @@
 # Copyright Cloudinary
 import sys
 
-PY3 = (sys.version_info.major == 3)
+PY3 = (sys.version_info[0] == 3)
 
 if PY3:
     import http.client as httplib


### PR DESCRIPTION
I'm still using python2.6 and the named tuple for version_info wasn't added until 2.7. This uses the index of the tuple instead for checking between 2 and 3.
