### PR TITLE
Added introspection rule for Django South

### DIFF
--- a/cloudinary/models.py
+++ b/cloudinary/models.py
@@ -3,6 +3,13 @@ from cloudinary import CloudinaryImage, forms, uploader
 from django.db import models
 from django.core.files.uploadedfile import UploadedFile
 
+# Add introspection rules for South, if it's installed.
+try:
+    from south.modelsinspector import add_introspection_rules
+    add_introspection_rules([], ["^cloudinary.models.CloudinaryField"])
+except ImportError:
+    pass
+
 class CloudinaryField(models.Field):
 
     description = "An image stored in Cloudinary"


### PR DESCRIPTION
I wanted to add my new CloudinaryField model field to the database using South, but South throws the error:

```
! Cannot freeze field 'myapp.mymodel.myimage'
! (this field has class cloudinary.models.CloudinaryField)

! South cannot introspect some fields; this is probably because they are custom
! fields. If they worked in 0.6 or below, this is because we have removed the
! models parser (it often broke things).
! To fix this, read http://south.aeracode.org/wiki/MyFieldsDontWork
```

I did this with the guidance of the South documentation: http://south.readthedocs.org/en/latest/customfields.html#extending-introspection

This will make the pycloudinary module "south aware"
