### PR TITLE
Generate secure urls automatically

### DIFF
--- a/cloudinary/templatetags/cloudinary.py
+++ b/cloudinary/templatetags/cloudinary.py
@@ -15,19 +15,19 @@ register = template.Library()
 def cloudinary_url(context, source, options_dict={}, **options):
     options = dict(options_dict, **options)
     try:
-        if context['request'].is_secure():
+        if context['request'].is_secure() and 'secure' not in options:
             options['secure'] = True
     except KeyError:
         pass
     if not isinstance(source, CloudinaryImage):
         source = CloudinaryImage(source)
-    return source.build_url(**options) 
+    return source.build_url(**options)
 
 @register.simple_tag(name='cloudinary', takes_context=True)
 def cloudinary_tag(context, image, options_dict={}, **options):
     options = dict(options_dict, **options)
     try:
-        if context['request'].is_secure():
+        if context['request'].is_secure() and 'secure' not in options:
             options['secure'] = True
     except KeyError:
         pass


### PR DESCRIPTION
If you have a page that is SSL secured through HTTPS, all elements should be also be loaded through SSL to prevent browser errors from appearing to the user, and to prevent possible information leaks.  Currently, if using cloudinary template tags, you have to specify secure=True manually every time you use it.  I modified the two template tags that generate URLs to automatically set secure=True if three conditions are met:
-  django.core.context_processors.request has been added to the site's TEMPLATE_CONTEXT_PROCESSORS setting.
  https://docs.djangoproject.com/en/1.6/ref/settings/#std:setting-TEMPLATE_CONTEXT_PROCESSORS
  https://docs.djangoproject.com/en/1.6/ref/templates/api/#django-core-context-processors-request
- The current request is served over a secure connection, and request.is_secure() returns True accordingly.
  https://docs.djangoproject.com/en/1.6/ref/request-response/#django.http.HttpRequest.is_secure
  https://docs.djangoproject.com/en/1.6/topics/security/#ssl-https
- The user hasn't specified a value for 'secure' in the template tag.

If any of those conditions are not met, the template tag will act like it always has, so should be backwards compatible.

Thanks,
Nathan Shafer
