### PR TITLE
Added __len__ function to CloudinaryImage

### DIFF
--- a/cloudinary/__init__.py
+++ b/cloudinary/__init__.py
@@ -91,6 +91,9 @@ class CloudinaryImage(object):
     def __unicode__(self):
         return self.public_id
 
+    def __len__(self):
+        return len(self.public_id)
+
     def validate(self):
         expected = utils.api_sign_request({"public_id": self.public_id, "version": self.version}, config().api_secret)
         return self.signature == expected

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -381,5 +381,16 @@ class ApiTest(unittest.TestCase):
             api.subfolders("test_folder")
         api.delete_resources_by_prefix("test_folder")
 
+    def test_CloudinaryImage_len(self):
+        """Tests the __len__ function on CloudinaryImage"""
+        metadata = {
+                "public_id": "test_id",
+                "format": "tst",
+                "version": "1234",
+                "signature": "5678",
+                }
+        myCloudinaryImage = cloudinary.CloudinaryImage(metadata=metadata)
+        self.assertEquals(len(myCloudinaryImage), len(metadata["public_id"]))
+
 if __name__ == '__main__':
     unittest.main() 


### PR DESCRIPTION
Django's MaxLengthValidator is called in Django Rest Framework
serializers on fields with max_length. This checks the value of the
CloudinaryImageField since it specifies a max_length of 100.
The value in the field is a CloudinaryImage which doesn't have
a __len__ function and errors out.

* added a __len__ function to CloudinaryImage that returns the length of
  public_id
* added a test