### PR TITLE
get_prep_value returns default instead of None

### DIFF
--- a/cloudinary/models.py
+++ b/cloudinary/models.py
@@ -75,7 +75,7 @@ class CloudinaryField(with_metaclass(models.SubfieldBase, models.Field)):
     def get_prep_value(self, value):
         prep = ''
         if not value:
-            return None
+            return self.get_default()
         if isinstance(value, CloudinaryResource):
             prep = prep + value.resource_type + '/' + value.type + '/'
             if value.version: prep = prep + 'v' + str(value.version) + '/'


### PR DESCRIPTION
Changed ``get_prep_value`` to return ``get_default()`` instead of ``None``. This was preventing the field from being non-nullable, as ``get_prep_value`` would always return None during the save process, preventing the field from using a default of an empty string ``''``, as both ``''`` and ``None`` would evaluate to ``False`` in the `if not value` conditional.

This commit fixes #56 

Quote from [Django's docs](https://docs.djangoproject.com/en/1.8/ref/models/fields/#null) on why you should avoid making CharFields nullable:
> Avoid using null on string-based fields such as CharField and TextField because empty string values will always be stored as empty strings, not as NULL. If a string-based field has null=True, that means it has two possible values for "no data": NULL, and the empty string. In most cases, it's redundant to have two possible values for "no data;" the Django convention is to use the empty string, not NULL.