### PR TITLE
fix _is_gae method

### DIFF
--- a/cloudinary/uploader.py
+++ b/cloudinary/uploader.py
@@ -233,4 +233,4 @@ def _is_gae():
         return False
     else:
         import httplib
-        return 'appengine' in str(httplib.HTTP)
+        return 'gae_override' in str(httplib.HTTP)


### PR DESCRIPTION
`str(httplib.HTTP)`return `'gae_override.httplib.HTTP'`, not `'appengine.httplib.HTTP'`
