### PR TITLE
Handle "not found" error while renaming

### DIFF
--- a/cloudinary/uploader.py
+++ b/cloudinary/uploader.py
@@ -200,7 +200,7 @@ def call_api(action, params, http_headers={}, return_error=False, unsigned=False
             response = urllib2.urlopen(request, **kw).read()
         except HTTPError:
             e = sys.exc_info()[1]
-            if not e.code in [200, 400, 500]:
+            if not e.code in [200, 400, 404, 500]:
                 raise Error("Server returned unexpected status code - %d - %s" % (e.code, e.read()))
             code = e.code
             response = e.read()

--- a/tests/uploader_test.py
+++ b/tests/uploader_test.py
@@ -61,8 +61,13 @@ class UploaderTest(unittest.TestCase):
         result = uploader.upload(TEST_IMAGE, tags=TEST_TAG)
         uploader.rename(result["public_id"], result["public_id"]+"2")
         self.assertIsNotNone(api.resource(result["public_id"]+"2"))
+        self.assertRaises(api.Error, uploader.rename, result["public_id"], result["public_id"]+"2")
+        self.assertDictEqual(uploader.rename(result["public_id"], result["public_id"]+"2", return_error=True),
+                {"error": {"http_code": 404, "message": "Resource not found - %s" % result["public_id"]}})
         result2 = uploader.upload("tests/favicon.ico", tags=TEST_TAG)
         self.assertRaises(api.Error, uploader.rename, result2["public_id"], result["public_id"]+"2")
+        self.assertDictEqual(uploader.rename(result2["public_id"], result["public_id"]+"2", return_error=True),
+                {"error": {"http_code": 400, "message": "to_public_id %s already exists" % (result["public_id"]+"2")}})
         uploader.rename(result2["public_id"], result["public_id"]+"2", overwrite=True)
         self.assertEqual(api.resource(result["public_id"]+"2")["format"], "ico")
 


### PR DESCRIPTION
The call_api function of the uploader module does not raise specific error, but converts all exceptions into the Error class. This approach makes it very difficult to handle errors appropriately. The solution to this problem might be to raise dedicated errors (same as the API module). However, for now, the simplest solution is to add the 404 code into the list of known codes.
