### PR TITLE
Support FileIO upload w/preexisting OS descriptors

### DIFF
--- a/cloudinary/uploader.py
+++ b/cloudinary/uploader.py
@@ -234,7 +234,7 @@ def call_api(action, params, http_headers=None, return_error=False, unsigned=Fal
             elif hasattr(file, 'read') and callable(file.read):
                 # stream
                 data = file.read()
-                name = file.name if hasattr(file, 'name') else "stream"
+                name = file.name if hasattr(file, 'name') and isinstance(file.name, str) else "stream"
             elif isinstance(file, tuple):
                 name = None
                 data = file


### PR DESCRIPTION
Without this fix, call_api crashes urllib3 in the standards-compliant
case where file.name is an int. Add support for this case.

From python.org, FileIO#name "can be one of two things:

- a character string or bytes object representing the path to the file which will be opened. In this case closefd must be True (the default) otherwise an error will be raised.
- an integer representing the number of an existing OS-level file descriptor to which the resulting FileIO object will give access. When the FileIO object is closed this fd will be closed as well, unless closefd is set to False."
(https://docs.python.org/3.5/library/io.html#io.FileIO)