### PR TITLE
Update `_get_val_from_object` method

### DIFF
--- a/cloudinary/models.py
+++ b/cloudinary/models.py
@@ -43,7 +43,16 @@ class CloudinaryField(models.Field):
         return 'CharField'
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        # We need to support both legacy `_get_val_from_obj` and new `value_from_object` models.Field methods.
+        # It would be better to wrap it with try -> except AttributeError -> fallback to legacy.
+        # Unfortunately, we can catch AttributeError exception from `value_from_object` function itself.
+        # Parsing exception string is an overkill here, that's why we check for attribute existence
+
+        if hasattr(self, 'value_from_object'):
+            value = self.value_from_object(obj)
+        else:  # fallback for legacy django versions
+            value = self._get_val_from_obj(obj)
+
         return self.get_prep_value(value)
 
     def parse_cloudinary_resource(self, value):

--- a/django_tests/test_cloudinaryField.py
+++ b/django_tests/test_cloudinaryField.py
@@ -45,10 +45,17 @@ class TestCloudinaryField(TestCase):
         res = CloudinaryImage(public_id=API_TEST_ID, format='jpg')
         self.assertEqual(c.get_prep_value(res), "image/upload/{}.jpg".format(API_TEST_ID))
 
+    def test_value_to_string(self):
+        c = CloudinaryField('image')
+        c.set_attributes_from_name('image')
+        image_field = Poll.objects.get(question="with image")
+        value_string = c.value_to_string(image_field)
+        self.assertEqual("image/upload/v1234/{name}.jpg".format(name=API_TEST_ID), value_string)
+
     def test_formfield(self):
         c = CloudinaryField('image')
-        for_field = c.formfield()
-        self.assertTrue(isinstance(for_field, CloudinaryFileField))
+        form_field = c.formfield()
+        self.assertTrue(isinstance(form_field, CloudinaryFileField))
 
     def test_empty_field(self):
         emptyField = Poll.objects.get(question="empty")


### PR DESCRIPTION
Using `value_from_object` method in the new Django versions
Add unit test for `value_to_string` method of `CloudinaryField`