### PR TITLE
Support structured metadata for upload

### DIFF
--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -101,6 +101,7 @@ __SIMPLE_UPLOAD_PARAMS = [
     "auto_tagging",
     "async",
     "cinemagraph_analysis",
+    "metadata"
 ]
 
 __SERIALIZED_UPLOAD_PARAMS = [


### PR DESCRIPTION
The SDK currently ignores structured metadata on upload. The change I made will allow the ability to accept the upload parameter `metadata` and use it to assign the structured metadata value. 

Currently, structured metadata field is ignored at upload with no error messages.