### PR TITLE
Add `accessibility_analysis` parameter support

### DIFF
--- a/cloudinary/api.py
+++ b/cloudinary/api.py
@@ -104,7 +104,8 @@ def resource(public_id, **options):
     upload_type = options.pop("type", "upload")
     uri = ["resources", resource_type, upload_type, public_id]
     params = only(options, "exif", "faces", "colors", "image_metadata", "cinemagraph_analysis",
-                  "pages", "phash", "coordinates", "max_results", "quality_analysis", "derived_next_cursor")
+                  "pages", "phash", "coordinates", "max_results", "quality_analysis", "derived_next_cursor",
+                  "accessibility_analysis")
     return call_api("get", uri, params, **options)
 
 

--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -103,6 +103,7 @@ __SIMPLE_UPLOAD_PARAMS = [
     "auto_tagging",
     "async",
     "cinemagraph_analysis",
+    "accessibility_analysis",
 ]
 
 __SERIALIZED_UPLOAD_PARAMS = [

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -828,6 +828,17 @@ class ApiTest(unittest.TestCase):
         self.assertIn("cinemagraph_analysis", params)
 
     @patch('urllib3.request.RequestMethods.request')
+    def test_accessibility_analysis_resource(self, mocker):
+        """ should allow the user to pass accessibility_analysis in the resource function """
+        mocker.return_value = MOCK_RESPONSE
+
+        api.resource(API_TEST_ID, accessibility_analysis=True)
+
+        params = get_params(mocker.call_args[0])
+
+        self.assertIn("accessibility_analysis", params)
+
+    @patch('urllib3.request.RequestMethods.request')
     def test_api_url_escapes_special_characters(self, mocker):
         """ should escape special characters in api url """
         mocker.return_value = MOCK_RESPONSE

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -706,6 +706,21 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         self.assertIn("cinemagraph_analysis", params)
 
     @patch('urllib3.request.RequestMethods.request')
+    def test_accessibility_analysis(self, request_mock):
+        """Should support accessibility analysis in upload and explicit"""
+        request_mock.return_value = MOCK_RESPONSE
+
+        uploader.upload(TEST_IMAGE, accessibility_analysis=True)
+
+        params = get_params(request_mock.call_args[0])
+        self.assertIn("accessibility_analysis", params)
+
+        uploader.explicit(TEST_IMAGE, accessibility_analysis=True)
+
+        params = get_params(request_mock.call_args[0])
+        self.assertIn("accessibility_analysis", params)
+
+    @patch('urllib3.request.RequestMethods.request')
     def test_eval_upload_parameter(self, request_mock):
         """Should support eval in upload and explicit"""
         request_mock.return_value = MOCK_RESPONSE


### PR DESCRIPTION
Add `accessibility_analysis` parameter to `upload`, `explicit`, and `resource` methods