### PR TITLE
support prededined_vars as modifiers and literals

### DIFF
--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -1144,7 +1144,7 @@ PREDEFINED_VARS = {
     "initial_duration": "idu",
 }
 
-replaceRE = "((\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*|\\^)(?=[ _])|(?<!\\$)(" + '|'.join(PREDEFINED_VARS.keys()) + "))"
+replaceRE = "((\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*|\\^)(?=[ _])|(?<![\\$\\:\\!])(" + '|'.join(PREDEFINED_VARS.keys()) + "))"
 
 
 def translate_if(match):


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Preventing predefined_vars substitution for this use-cases:
- literals, e.g.: $var_!duration!
- modifiers, e.g.: "effect": "preview:duration_420:max_seg_25:min_seg_dur_10"
-->

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[ ] New feature
[x] Bug fix
[ ] Adds more tests

#### Are tests included?
[ ] Yes
[x] No

#### Reviewer, Please Note:
<!--
 
-->
