### PR TITLE
Added helper function to ensure add on tests do not run by default

### DIFF
--- a/test/helper_test.py
+++ b/test/helper_test.py
@@ -1,14 +1,14 @@
 # -*- coding: latin-1 -*-
 import json
-from contextlib import contextmanager
 import os
 import random
 import re
 import sys
 import time
+import traceback
+from contextlib import contextmanager
 from datetime import timedelta, tzinfo
 from functools import wraps
-import traceback
 
 import six
 from urllib3 import HTTPResponse
@@ -35,32 +35,30 @@ UNIQUE_TEST_FOLDER = UNIQUE_TAG + "_folder"
 
 ZERO = timedelta(0)
 
-EVAL_STR='if (resource_info["width"] < 450) { upload_options["tags"] = "a,b" }; ' \
-         'upload_options["context"] = "width=" + resource_info["width"]'
+EVAL_STR = 'if (resource_info["width"] < 450) { upload_options["tags"] = "a,b" }; ' \
+           'upload_options["context"] = "width=" + resource_info["width"]'
 
-ADDON_ALL = 'all'                                                   # Test all addons.
-ADDON_ASPOSE = 'aspose'                                             # Aspose Document Conversion.
-ADDON_AZURE = 'azure'                                               # Microsoft Azure Video Indexer.
-ADDON_BG_REMOVAL = 'bgremoval'                                      # Cloudinary AI Background Removal.
-ADDON_FACIAL_ATTRIBUTES_DETECTION = 'facialattributesdetection'     # Advanced Facial Attributes Detection.
-ADDON_GOOGLE = 'google'                                             # Google AI Video Moderation, Google AI
-                                                                    # Video Transcription, Google Auto Tagging,
-                                                                    # Google Automatic Video Tagging,
-                                                                    # Google Translation.
-ADDON_IMAGGA = 'imagga'                                             # Imagga Auto Tagging, Imagga Crop and Scale.
-ADDON_JPEGMINI = 'jpegmini'                                         # JPEGmini Image Optimization.
-ADDON_LIGHTROOM = 'lightroom'                                       # Adobe Photoshop Lightroom (BETA).
-ADDON_METADEFENDER = 'metadefender'                                 # MetaDefender Anti-Malware Protection.
-ADDON_NEURAL_ARTWORK = 'neuralartwork'                              # Neural Artwork Style Transfer.
-ADDON_OBJECT_AWARE_CROPPING = 'objectawarecropping'                 # Cloudinary Object-Aware Cropping.
-ADDON_OCR = 'ocr'                                                   # OCR Text Detection and Extraction.
-ADDON_PIXELZ = 'pixelz'                                             # Remove the Background.
-ADDON_REKOGNITION = 'rekognition'                                   # Amazon Rekognition AI Moderation,
-                                                                    # Amazon Rekognition Auto Tagging,
-                                                                    # Amazon Rekognition Celebrity Detection.
-ADDON_URL2PNG = 'url2png'                                           # URL2PNG Website Screenshots.
-ADDON_VIESUS = 'viesus'                                             # VIESUS Automatic Image Enhancement.
-ADDON_WEBPURIFY = 'webpurify'                                       # WebPurify Image Moderation.
+ADDON_ALL = 'all'  # Test all addons.
+ADDON_ASPOSE = 'aspose'  # Aspose Document Conversion.
+ADDON_AZURE = 'azure'  # Microsoft Azure Video Indexer.
+ADDON_BG_REMOVAL = 'bgremoval'  # Cloudinary AI Background Removal.
+ADDON_FACIAL_ATTRIBUTES_DETECTION = 'facialattributesdetection'  # Advanced Facial Attributes Detection.
+# Google AI Video Moderation, Google AI, Video Transcription, Google Auto Tagging, Google Automatic Video Tagging,
+# Google Translation.
+ADDON_GOOGLE = 'google'
+ADDON_IMAGGA = 'imagga'  # Imagga Auto Tagging, Imagga Crop and Scale.
+ADDON_JPEGMINI = 'jpegmini'  # JPEGmini Image Optimization.
+ADDON_LIGHTROOM = 'lightroom'  # Adobe Photoshop Lightroom (BETA).
+ADDON_METADEFENDER = 'metadefender'  # MetaDefender Anti-Malware Protection.
+ADDON_NEURAL_ARTWORK = 'neuralartwork'  # Neural Artwork Style Transfer.
+ADDON_OBJECT_AWARE_CROPPING = 'objectawarecropping'  # Cloudinary Object-Aware Cropping.
+ADDON_OCR = 'ocr'  # OCR Text Detection and Extraction.
+ADDON_PIXELZ = 'pixelz'  # Remove the Background.
+# Amazon Rekognition AI Moderation, Amazon Rekognition Auto Tagging, Amazon Rekognition Celebrity Detection.
+ADDON_REKOGNITION = 'rekognition'
+ADDON_URL2PNG = 'url2png'  # URL2PNG Website Screenshots.
+ADDON_VIESUS = 'viesus'  # VIESUS Automatic Image Enhancement.
+ADDON_WEBPURIFY = 'webpurify'  # WebPurify Image Moderation.
 
 
 class UTC(tzinfo):
@@ -166,6 +164,7 @@ def retry_assertion(num_tries=3, delay=3):
     :param num_tries: Number of tries to perform
     :param delay: Delay in seconds between retries
     """
+
     def retry_decorator(func):
         @wraps(func)
         def retry_func(*args, **kwargs):

--- a/test/helper_test.py
+++ b/test/helper_test.py
@@ -38,6 +38,30 @@ ZERO = timedelta(0)
 EVAL_STR='if (resource_info["width"] < 450) { upload_options["tags"] = "a,b" }; ' \
          'upload_options["context"] = "width=" + resource_info["width"]'
 
+ADDON_ALL = 'all'                                                   # Test all addons.
+ADDON_ASPOSE = 'aspose'                                             # Aspose Document Conversion.
+ADDON_AZURE = 'azure'                                               # Microsoft Azure Video Indexer.
+ADDON_BG_REMOVAL = 'bgremoval'                                      # Cloudinary AI Background Removal.
+ADDON_FACIAL_ATTRIBUTES_DETECTION = 'facialattributesdetection'     # Advanced Facial Attributes Detection.
+ADDON_GOOGLE = 'google'                                             # Google AI Video Moderation, Google AI
+                                                                    # Video Transcription, Google Auto Tagging,
+                                                                    # Google Automatic Video Tagging,
+                                                                    # Google Translation.
+ADDON_IMAGGA = 'imagga'                                             # Imagga Auto Tagging, Imagga Crop and Scale.
+ADDON_JPEGMINI = 'jpegmini'                                         # JPEGmini Image Optimization.
+ADDON_LIGHTROOM = 'lightroom'                                       # Adobe Photoshop Lightroom (BETA).
+ADDON_METADEFENDER = 'metadefender'                                 # MetaDefender Anti-Malware Protection.
+ADDON_NEURAL_ARTWORK = 'neuralartwork'                              # Neural Artwork Style Transfer.
+ADDON_OBJECT_AWARE_CROPPING = 'objectawarecropping'                 # Cloudinary Object-Aware Cropping.
+ADDON_OCR = 'ocr'                                                   # OCR Text Detection and Extraction.
+ADDON_PIXELZ = 'pixelz'                                             # Remove the Background.
+ADDON_REKOGNITION = 'rekognition'                                   # Amazon Rekognition AI Moderation,
+                                                                    # Amazon Rekognition Auto Tagging,
+                                                                    # Amazon Rekognition Celebrity Detection.
+ADDON_URL2PNG = 'url2png'                                           # URL2PNG Website Screenshots.
+ADDON_VIESUS = 'viesus'                                             # VIESUS Automatic Image Enhancement.
+ADDON_WEBPURIFY = 'webpurify'                                       # WebPurify Image Moderation.
+
 
 class UTC(tzinfo):
     """UTC"""
@@ -191,3 +215,18 @@ def cleanup_test_transformation(params):
         for transformation in transformations_with_options[0]:
             with ignore_exception(suppress_traceback_classes=(NotFound,)):
                 api.delete_transformation(transformation, **options)
+
+
+def should_test_addon(addon):
+    """
+    Checks whether a certain add-on should be tested.
+    :param addon: The add-on name.
+    :type addon:  str
+    :return:      True if that add-on should be tested, False otherwise.
+    :rtype:       bool
+    """
+    cld_test_addons = os.environ.get('CLD_TEST_ADDONS').lower()
+    if cld_test_addons == ADDON_ALL:
+        return True
+    cld_test_addons_list = [addon_name.strip() for addon_name in cld_test_addons.split(',')]
+    return addon in cld_test_addons_list


### PR DESCRIPTION
### Brief Summary of Changes

Added the `should_test_addon() ` function which can be used at the beginning of tests to test whether a certain add on should be tested and allow skipping those that shouldn't.

To enable certain add on testing add its id to the `CLD_TEST_ADDONS` environment variable. Alternatively set `CLD_TEST_ADDONS` to `all` to test all add ons.

#### What does this PR address?
[x] New feature

#### Are tests included?
[ ] Yes
[x] No

#### Reviewer, Please Note:

Consider adding `CLD_TEST_ADDONS=all` to Travis.