### PR TITLE
Extract addon type constants to a separate file

### DIFF
--- a/test/addon_types.py
+++ b/test/addon_types.py
@@ -1,0 +1,21 @@
+ADDON_ALL = 'all'  # Test all addons.
+ADDON_ASPOSE = 'aspose'  # Aspose Document Conversion.
+ADDON_AZURE = 'azure'  # Microsoft Azure Video Indexer.
+ADDON_BG_REMOVAL = 'bgremoval'  # Cloudinary AI Background Removal.
+ADDON_FACIAL_ATTRIBUTES_DETECTION = 'facialattributesdetection'  # Advanced Facial Attributes Detection.
+# Google AI Video Moderation, Google AI, Video Transcription, Google Auto Tagging, Google Automatic Video Tagging,
+# Google Translation.
+ADDON_GOOGLE = 'google'
+ADDON_IMAGGA = 'imagga'  # Imagga Auto Tagging, Imagga Crop and Scale.
+ADDON_JPEGMINI = 'jpegmini'  # JPEGmini Image Optimization.
+ADDON_LIGHTROOM = 'lightroom'  # Adobe Photoshop Lightroom (BETA).
+ADDON_METADEFENDER = 'metadefender'  # MetaDefender Anti-Malware Protection.
+ADDON_NEURAL_ARTWORK = 'neuralartwork'  # Neural Artwork Style Transfer.
+ADDON_OBJECT_AWARE_CROPPING = 'objectawarecropping'  # Cloudinary Object-Aware Cropping.
+ADDON_OCR = 'ocr'  # OCR Text Detection and Extraction.
+ADDON_PIXELZ = 'pixelz'  # Remove the Background.
+# Amazon Rekognition AI Moderation, Amazon Rekognition Auto Tagging, Amazon Rekognition Celebrity Detection.
+ADDON_REKOGNITION = 'rekognition'
+ADDON_URL2PNG = 'url2png'  # URL2PNG Website Screenshots.
+ADDON_VIESUS = 'viesus'  # VIESUS Automatic Image Enhancement.
+ADDON_WEBPURIFY = 'webpurify'  # WebPurify Image Moderation.

--- a/test/helper_test.py
+++ b/test/helper_test.py
@@ -9,6 +9,7 @@ import traceback
 from contextlib import contextmanager
 from datetime import timedelta, tzinfo
 from functools import wraps
+from test.addon_types import ADDON_ALL
 
 import six
 from urllib3 import HTTPResponse
@@ -37,28 +38,6 @@ ZERO = timedelta(0)
 
 EVAL_STR = 'if (resource_info["width"] < 450) { upload_options["tags"] = "a,b" }; ' \
            'upload_options["context"] = "width=" + resource_info["width"]'
-
-ADDON_ALL = 'all'  # Test all addons.
-ADDON_ASPOSE = 'aspose'  # Aspose Document Conversion.
-ADDON_AZURE = 'azure'  # Microsoft Azure Video Indexer.
-ADDON_BG_REMOVAL = 'bgremoval'  # Cloudinary AI Background Removal.
-ADDON_FACIAL_ATTRIBUTES_DETECTION = 'facialattributesdetection'  # Advanced Facial Attributes Detection.
-# Google AI Video Moderation, Google AI, Video Transcription, Google Auto Tagging, Google Automatic Video Tagging,
-# Google Translation.
-ADDON_GOOGLE = 'google'
-ADDON_IMAGGA = 'imagga'  # Imagga Auto Tagging, Imagga Crop and Scale.
-ADDON_JPEGMINI = 'jpegmini'  # JPEGmini Image Optimization.
-ADDON_LIGHTROOM = 'lightroom'  # Adobe Photoshop Lightroom (BETA).
-ADDON_METADEFENDER = 'metadefender'  # MetaDefender Anti-Malware Protection.
-ADDON_NEURAL_ARTWORK = 'neuralartwork'  # Neural Artwork Style Transfer.
-ADDON_OBJECT_AWARE_CROPPING = 'objectawarecropping'  # Cloudinary Object-Aware Cropping.
-ADDON_OCR = 'ocr'  # OCR Text Detection and Extraction.
-ADDON_PIXELZ = 'pixelz'  # Remove the Background.
-# Amazon Rekognition AI Moderation, Amazon Rekognition Auto Tagging, Amazon Rekognition Celebrity Detection.
-ADDON_REKOGNITION = 'rekognition'
-ADDON_URL2PNG = 'url2png'  # URL2PNG Website Screenshots.
-ADDON_VIESUS = 'viesus'  # VIESUS Automatic Image Enhancement.
-ADDON_WEBPURIFY = 'webpurify'  # WebPurify Image Moderation.
 
 
 class UTC(tzinfo):


### PR DESCRIPTION
Addon type constants are extracted to their own file as was done in other SDKs.

Note that when doing this we could have gone with one of two approaches:
1. `import test.addon_types` and then use it as `should_test_addon(addon_types.AZURE)`
2. `from test.addon_types import ADDON_AZURE` and then simply use it as `should_test_addon(ADDON_AZURE)`

The first is more like the two PHP implementations. The second which we chose is more in line with the rest of the Python SDK.
