### PR TITLE
Change test for `eval` upload parameter

### DIFF
--- a/test/helper_test.py
+++ b/test/helper_test.py
@@ -35,7 +35,7 @@ UNIQUE_TEST_FOLDER = UNIQUE_TAG + "_folder"
 
 ZERO = timedelta(0)
 
-EVAL_STR = 'if (resource_info["width"] < 450) { upload_options["tags"] = "a,b" }; ' \
+EVAL_STR = 'if (resource_info["width"] < 450) { upload_options["quality_analysis"] = true }; ' \
            'upload_options["context"] = "width=" + resource_info["width"]'
 
 ADDON_ALL = 'all'  # Test all addons.

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -720,22 +720,13 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         params = get_params(request_mock.call_args[0])
         self.assertIn("accessibility_analysis", params)
 
-    @patch('urllib3.request.RequestMethods.request')
-    def test_eval_upload_parameter(self, request_mock):
-        """Should support eval in upload and explicit"""
-        request_mock.return_value = MOCK_RESPONSE
-
-        uploader.upload(TEST_IMAGE, eval=EVAL_STR)
-
-        params = get_params(request_mock.call_args[0])
-        self.assertIn("eval", params)
-        self.assertEqual(EVAL_STR, params["eval"])
-
-        uploader.explicit(TEST_IMAGE, eval=EVAL_STR)
-
-        params = get_params(request_mock.call_args[0])
-        self.assertIn("eval", params)
-        self.assertEqual(EVAL_STR, params["eval"])
+    @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
+    def test_eval_upload_parameter(self):
+        """Should support eval in upload"""
+        result = uploader.upload(TEST_IMAGE, eval=EVAL_STR, tags=[UNIQUE_TAG])
+        self.assertEqual(str(result['context']['custom']['width']), str(TEST_IMAGE_WIDTH))
+        self.assertIsInstance(result['quality_analysis'], dict)
+        self.assertIsInstance(result['quality_analysis']['focus'], float)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Brief Summary of Changes

The test for `eval` has a bug that causes it to leave leftover images that weren't deleted during test teardown.

This happens because the current eval test overwrites the tags of the uploaded image, including the tag used in the teardown to delete it.

This PR changes the eval string to test how it does something other than changing tags.

#### What does this PR address?
- [x] Bug fix

#### Are tests included?
- [x] Yes

