### PR TITLE
Add SHA-256 support for auth signatures

### DIFF
--- a/cloudinary/__init__.py
+++ b/cloudinary/__init__.py
@@ -17,15 +17,6 @@ formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(messag
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 
-SIGNATURE_SHA1 = "sha1"
-SIGNATURE_SHA256 = "sha256"
-SIGNATURE_ALGORITHMS = {
-    SIGNATURE_SHA1: hashlib.sha1,
-    SIGNATURE_SHA256: hashlib.sha256,
-}
-SHORT_URL_SIGNATURE_LENGTH = 8
-LONG_URL_SIGNATURE_LENGTH = 32
-
 from cloudinary import utils
 from cloudinary.exceptions import GeneralError
 from cloudinary.cache import responsive_breakpoints_cache
@@ -185,7 +176,7 @@ class Config(BaseConfig):
             parsed_url = self._parse_cloudinary_url(cloudinary_url)
             self._setup_from_parsed_url(parsed_url)
         if not self.signature_algorithm:
-            self.signature_algorithm = SIGNATURE_SHA1
+            self.signature_algorithm = utils.SIGNATURE_SHA1
 
     def _config_from_parsed_url(self, parsed_url):
         if not self._is_url_scheme_valid(parsed_url):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -642,7 +642,7 @@ class TestUtils(unittest.TestCase):
     def test_signed_url_sha256(self):
         sha256_config = cloudinary.Config()
         sha256_config.update(**vars(cloudinary.config()))
-        sha256_config.update(signature_algorithm=cloudinary.SIGNATURE_SHA256)
+        sha256_config.update(signature_algorithm=cloudinary.utils.SIGNATURE_SHA256)
         with patch('cloudinary.config', return_value=sha256_config):
             self.__test_cloudinary_url(
                 public_id="sample.jpg",
@@ -1280,7 +1280,7 @@ class TestUtils(unittest.TestCase):
                 public_id,
                 test_version,
                 api_response_signature,
-                cloudinary.SIGNATURE_SHA256
+                cloudinary.utils.SIGNATURE_SHA256
             ))
 
     def test_verify_notification_signature(self):
@@ -1331,7 +1331,7 @@ class TestUtils(unittest.TestCase):
                     0,
                     "d5497e1a206ad0ba29ad09a7c0c5f22e939682d15009c15ab3199f62fefbd14b",
                     valid_for=time.time(),
-                    algorithm=cloudinary.SIGNATURE_SHA256))
+                    algorithm=cloudinary.utils.SIGNATURE_SHA256))
 
     def test_support_long_url_signature(self):
         """should generate short signature by default and long signature if long_url_signature=True"""
@@ -1363,7 +1363,7 @@ class TestUtils(unittest.TestCase):
 
     def test_api_sign_request_sha256(self):
         params = dict(cloud_name="dn6ot3ged", timestamp=1568810420, username="user@cloudinary.com")
-        signature = api_sign_request(params, "hdcixPpR2iKERPwqvH6sHdK9cyac", cloudinary.SIGNATURE_SHA256)
+        signature = api_sign_request(params, "hdcixPpR2iKERPwqvH6sHdK9cyac", cloudinary.utils.SIGNATURE_SHA256)
         expected = "45ddaa4fa01f0c2826f32f669d2e4514faf275fe6df053f1a150e7beae58a3bd"
         self.assertEqual(expected, signature)
 


### PR DESCRIPTION
### Brief Summary of Changes
Add support of SHA256 authentication signature alongside with SHA1. Algorithm is passed as an optional parameter to signature-related functions as well as config option. By default SHA1 is used

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[X] New feature
[ ] Bug fix
[ ] Adds more tests

#### Are tests included?
[X] Yes
[ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
