### PR TITLE
Allow 'multi' and 'sprite' with urls, add 'download_generated_sprite' and 'download_multi' methods

### DIFF
--- a/cloudinary/uploader.py
+++ b/cloudinary/uploader.py
@@ -213,14 +213,8 @@ def download_generated_sprite(tag=None, urls=None, **options):
     :return:        The signed URL to download sprite
     :rtype:         str
     """
-    params = options.copy()
-    params.update(mode="download")
-
-    params = utils.build_multi_and_sprite_params(tag=tag, urls=urls, **params)
-    cloudinary_params = utils.sign_request(params, options)
-
-    return utils.cloudinary_api_url("sprite", **options) + "?" + \
-        utils.urlencode(utils.bracketize_seq(cloudinary_params), True)
+    params = utils.build_multi_and_sprite_params(tag=tag, urls=urls, **options)
+    return utils.cloudinary_api_download_url(action="sprite", params=params, **options)
 
 
 def multi(tag=None, urls=None, **options):
@@ -257,14 +251,8 @@ def download_multi(tag=None, urls=None, **options):
     :return:        The signed URL to download multi
     :rtype:         str
     """
-    params = options.copy()
-    params.update(mode="download")
-
-    params = utils.build_multi_and_sprite_params(tag=tag, urls=urls, **params)
-    cloudinary_params = utils.sign_request(params, options)
-
-    return utils.cloudinary_api_url("multi", **options) + "?" + \
-        utils.urlencode(utils.bracketize_seq(cloudinary_params), True)
+    params = utils.build_multi_and_sprite_params(tag=tag, urls=urls, **options)
+    return utils.cloudinary_api_download_url(action="multi", params=params, **options)
 
 
 def explode(public_id, **options):

--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -777,6 +777,13 @@ def cloudinary_api_url(action='upload', **options):
     return base_api_url([resource_type, action], **options)
 
 
+def cloudinary_api_download_url(action, params, **options):
+    params = params.copy()
+    params["mode"] = "download"
+    cloudinary_params = sign_request(params, options)
+    return cloudinary_api_url(action, **options) + "?" + urlencode(bracketize_seq(cloudinary_params), True)
+
+
 def cloudinary_scaled_url(source, width, transformation, options):
     """
     Generates a cloudinary url scaled to specified width.
@@ -875,11 +882,7 @@ def bracketize_seq(params):
 
 
 def download_archive_url(**options):
-    params = options.copy()
-    params.update(mode="download")
-    cloudinary_params = sign_request(archive_params(**params), options)
-    return cloudinary_api_url("generate_archive", **options) + "?" + \
-        urlencode(bracketize_seq(cloudinary_params), True)
+    return cloudinary_api_download_url(action="generate_archive", params=archive_params(**options), **options)
 
 
 def download_zip_url(**options):
@@ -1043,10 +1046,8 @@ def build_multi_and_sprite_params(**options):
     """
     tag = options.get("tag")
     urls = options.get("urls")
-    if tag and urls:
-        raise ValueError("'tag' and 'urls' parameters are mutually exclusive")
-    if not tag and not urls:
-        raise ValueError("Either 'tag' or 'urls' parameter has to be set")
+    if bool(tag) == bool(urls):
+        raise ValueError("Either 'tag' or 'urls' parameter has to be set but not both")
     params = {
         "mode": options.get("mode"),
         "timestamp": now(),

--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -1037,6 +1037,28 @@ def build_upload_params(**options):
     return params
 
 
+def build_multi_and_sprite_params(**options):
+    """
+    Build params for multi, download_multi, generate_sprite, and download_generated_sprite methods
+    """
+    tag = options.get("tag")
+    urls = options.get("urls")
+    if tag and urls:
+        raise ValueError("'tag' and 'urls' parameters are mutually exclusive")
+    if not tag and not urls:
+        raise ValueError("Either 'tag' or 'urls' parameter has to be set")
+    params = {
+        "mode": options.get("mode"),
+        "timestamp": now(),
+        "async": options.get("async"),
+        "notification_url": options.get("notification_url"),
+        "tag": tag,
+        "urls": urls,
+        "transformation": generate_transformation_string(fetch_format=options.get("format"), **options)[0]
+    }
+    return params
+
+
 def __process_text_options(layer, layer_parameter):
     font_family = layer.get("font_family")
     font_size = layer.get("font_size")

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -410,9 +410,8 @@ class ApiTest(unittest.TestCase):
         """ should allow listing transformations with cursor """
         mocker.return_value = MOCK_RESPONSE
         api.transformation(API_TEST_TRANS_SCALE100, next_cursor=NEXT_CURSOR, max_results=10)
-        params = mocker.call_args[0][2]
-        self.assertEqual(params['next_cursor'], NEXT_CURSOR)
-        self.assertEqual(params['max_results'], 10)
+        self.assertEqual(get_param(mocker, 'next_cursor'), NEXT_CURSOR)
+        self.assertEqual(get_param(mocker, 'max_results'), 10)
 
     @patch('urllib3.request.RequestMethods.request')
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
@@ -420,7 +419,7 @@ class ApiTest(unittest.TestCase):
         """ should allow listing only named transformations"""
         mocker.return_value = MOCK_RESPONSE
         api.transformations(named=True)
-        params = mocker.call_args[0][2]
+        params = get_params(mocker.call_args[0])
         self.assertEqual(params['named'], True)
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
@@ -580,8 +579,8 @@ class ApiTest(unittest.TestCase):
         """ should support notification_url param """
         mocker.return_value = MOCK_RESPONSE
         api.update("api_test", notification_url="http://example.com")
-        params = mocker.call_args[0][2]
-        self.assertEqual(params['notification_url'], "http://example.com")
+        notification_url = get_param(mocker, 'notification_url')
+        self.assertEqual(notification_url, "http://example.com")
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test22_raw_conversion(self):
@@ -620,8 +619,8 @@ class ApiTest(unittest.TestCase):
         test_values = ['auto:advanced', 'auto:best', '80:420', 'none']
         for quality in test_values:
             api.update("api_test", quality_override=quality)
-            params = mocker.call_args[0][2]
-            self.assertEqual(params['quality_override'], quality)
+            quality_override = get_param(mocker, 'quality_override')
+            self.assertEqual(quality_override, quality)
 
     @patch('urllib3.request.RequestMethods.request')
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")

--- a/test/test_archive.py
+++ b/test/test_archive.py
@@ -15,7 +15,7 @@ import urllib3
 from urllib3 import disable_warnings
 
 from test.helper_test import SUFFIX, TEST_IMAGE, api_response_mock, cleanup_test_resources_by_tag, UNIQUE_TEST_ID, \
-    get_uri, get_list_param
+    get_uri, get_list_param, get_params
 
 MOCK_RESPONSE = api_response_mock()
 
@@ -60,7 +60,7 @@ class ArchiveTest(unittest.TestCase):
             allow_missing=True,
             skip_transformation_name=True,
         )
-        params = mocker.call_args[0][2]
+        params = get_params(mocker.call_args[0])
         self.assertEqual(params['expires_at'], expires_at)
         self.assertTrue(params['allow_missing'])
         self.assertTrue(params['skip_transformation_name'])

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -796,15 +796,15 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         parameters = parse_qs(urlparse(url_from_tag).query)
         self.assertEqual(sprite_test_tag, parameters["tag"][0])
         self.assertEqual("download", parameters["mode"][0])
-        self.assertTrue(parameters["timestamp"])
-        self.assertTrue(parameters["signature"])
+        self.assertIn("timestamp", parameters)
+        self.assertIn("signature", parameters)
 
         parameters = parse_qs(urlparse(url_from_urls).query)
         self.assertIn(url_1, parameters["urls[]"])
         self.assertIn(url_2, parameters["urls[]"])
         self.assertEqual("download", parameters["mode"][0])
-        self.assertTrue(parameters["timestamp"])
-        self.assertTrue(parameters["signature"])
+        self.assertIn("timestamp", parameters)
+        self.assertIn("signature", parameters)
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_multi(self):
@@ -845,15 +845,15 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         parameters = parse_qs(urlparse(url_from_tag).query)
         self.assertEqual(multi_test_tag, parameters["tag"][0])
         self.assertEqual("download", parameters["mode"][0])
-        self.assertTrue(parameters["timestamp"])
-        self.assertTrue(parameters["signature"])
+        self.assertIn("timestamp", parameters)
+        self.assertIn("signature", parameters)
 
         parameters = parse_qs(urlparse(url_from_urls).query)
         self.assertIn(url_1, parameters["urls[]"])
         self.assertIn(url_2, parameters["urls[]"])
         self.assertEqual("download", parameters["mode"][0])
-        self.assertTrue(parameters["timestamp"])
-        self.assertTrue(parameters["signature"])
+        self.assertIn("timestamp", parameters)
+        self.assertIn("signature", parameters)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Brief Summary of Changes
Add support for urls list as source for sprites and multi.

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[X] New feature
[ ] Bug fix
[ ] Adds more tests

#### Are tests included?
[X] Yes
[ ] No

#### Reviewer, Please Note:
- `tag` parameter is kept for backward compatibility. 
- `urls` parameter is added as an explicit param rather than getting it from options to give it a better discoverability
- download_ functions kept with both urls and tag even though they are new for api consistency
- reasoning for call_api changes in uploader: parameters were created as dict, so no name duplicates allowed. For list params, like urls, instead of 'urls[]=' like in e.g. [java SDK](https://github.com/cloudinary/cloudinary_java/blob/480518a01e966dfb0d4336a5131eab6a221a9f02/cloudinary-http42/src/main/java/com/cloudinary/http42/UploaderStrategy.java#L79)   it was creating 'urls[0]=', 'urls[1]=',....  This format was parsed by server as a dictionary, causing signature mismatch. Changes from dict to list for request fields caused changes to some tests which mock http requests.

