### PR TITLE
Fix `pending` parameter of the `users` method of provisioning API

### DIFF
--- a/cloudinary/provisioning/account.py
+++ b/cloudinary/provisioning/account.py
@@ -135,7 +135,9 @@ def users(user_ids=None, sub_account_id=None, pending=None, prefix=None, **optio
     :type user_ids:         list, optional
     :param sub_account_id:  The id of a sub account
     :type sub_account_id:   str, optional
-    :param pending:         Whether the user is pending
+    :param pending:         Limit results to pending users (True),
+                            users that are not pending (False),
+                            or all users (None, the default).
     :type pending:          bool, optional
     :param prefix:          User prefix
     :type prefix:           str, optional

--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -548,7 +548,7 @@ def process_params(params):
             if isinstance(value, list) or isinstance(value, tuple):
                 value_list = {"{}[{}]".format(key, i): i_value for i, i_value in enumerate(value)}
                 processed_params.update(value_list)
-            elif value:
+            elif value is not None:
                 processed_params[key] = value
     return processed_params
 

--- a/test/helper_test.py
+++ b/test/helper_test.py
@@ -32,6 +32,7 @@ TEST_ICON = RESOURCES_PATH + "favicon.ico"
 TEST_TAG = "pycloudinary_test"
 UNIQUE_TAG = "{0}_{1}".format(TEST_TAG, SUFFIX)
 UNIQUE_TEST_ID = UNIQUE_TAG
+UNIQUE_SUB_ACCOUNT_ID = UNIQUE_TAG
 UNIQUE_TEST_FOLDER = UNIQUE_TAG + "_folder"
 
 ZERO = timedelta(0)

--- a/test/test_provisioning_api.py
+++ b/test/test_provisioning_api.py
@@ -1,4 +1,3 @@
-import random
 import unittest
 from datetime import datetime
 
@@ -8,6 +7,8 @@ from urllib3 import disable_warnings
 import cloudinary.provisioning.account
 from cloudinary.provisioning import account_config, reset_config
 from cloudinary.exceptions import AuthorizationRequired, NotFound
+
+from test.helper_test import UNIQUE_SUB_ACCOUNT_ID
 
 disable_warnings()
 
@@ -157,9 +158,8 @@ class AccountApiTest(unittest.TestCase):
     @unittest.skipUnless(cloudinary.provisioning.account_config().provisioning_api_secret,
                          "requires provisioning_api_key/provisioning_api_secret")
     def test_get_users_by_nonexistent_sub_account_id(self):
-        random_id = random.randint(100000, 999999)
-        with six.assertRaisesRegex(self, NotFound, "Cannot find sub account with id {}".format(random_id)):
-            cloudinary.provisioning.users(pending=True, sub_account_id=random_id)
+        with six.assertRaisesRegex(self, NotFound, "Cannot find sub account with id {}".format(UNIQUE_SUB_ACCOUNT_ID)):
+            cloudinary.provisioning.users(pending=True, sub_account_id=UNIQUE_SUB_ACCOUNT_ID)
 
     @unittest.skipUnless(cloudinary.provisioning.account_config().provisioning_api_secret,
                          "requires provisioning_api_key/provisioning_api_secret")


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->
The `users()` method in the API behaves in 3 distinct ways.

- If pending is true it returns only pending users.
- If pending is false it returns only non-pending users.
- If pending is undefined it returns all users regardless of pending status.

False value was not supported and parameter description was misleading

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[ ] New feature
[x] Bug fix
[ ] Adds more tests

#### Are tests included?
[x] Yes
[ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
`process_params` change is a bit risky since it affects not only `users()` and will pass False parameters to the server that previously were not passed. But otherwise it will either require code duplication (e.g. separate `execute_request`) or additional options to pass where to keep old behaviour or not. Both alternatives worsen maintainability of the SDK. Please let me know if you still prefer to avoid this change.