### PR TITLE
Add validation to `generate_auth_token` to enforce url or acl

### DIFF
--- a/cloudinary/auth_token.py
+++ b/cloudinary/auth_token.py
@@ -20,6 +20,9 @@ def generate(url=None, acl=None, start_time=None, duration=None,
         else:
             raise Exception("Must provide either expiration or duration")
 
+    if url is None and acl is None:
+        raise Exception("Must provide either acl or url")
+
     token_parts = []
     if ip is not None:
         token_parts.append("ip=" + ip)

--- a/test/test_auth_token.py
+++ b/test/test_auth_token.py
@@ -102,12 +102,19 @@ class AuthTokenTest(unittest.TestCase):
     def test_must_provide_acl_or_url(self):
         self.assertRaises(Exception, cloudinary.utils.generate_auth_token, start_time=1111111111, duration=300)
 
-        cloudinary.utils.generate_auth_token(start_time=1111111111, duration=300, acl="/*/t_foobar")
-        cloudinary.utils.generate_auth_token(
+    def test_should_support_url_without_acl(self):
+        url_token = cloudinary.utils.generate_auth_token(
             start_time=1111111111,
             duration=300,
             url="http://res.cloudinary.com/test123/image/upload/v1486020273/sample.jpg"
         )
+
+        self.assertEqual(
+            url_token,
+            "__cld_token__=st=1111111111~exp=1111111411~hmac="
+            "639406f8c07fc6a1613e1f6192baba631f9d5719185a32049281e94e15c5619b"
+        )
+
 
 
 if __name__ == '__main__':

--- a/test/test_auth_token.py
+++ b/test/test_auth_token.py
@@ -99,6 +99,16 @@ class AuthTokenTest(unittest.TestCase):
     def test_must_provide_expiration_or_duration(self):
         self.assertRaises(Exception, cloudinary.utils.generate_auth_token, acl="*", expiration=None, duration=None)
 
+    def test_must_provide_acl_or_url(self):
+        self.assertRaises(Exception, cloudinary.utils.generate_auth_token, start_time=1111111111, duration=300)
+
+        cloudinary.utils.generate_auth_token(start_time=1111111111, duration=300, acl="/*/t_foobar")
+        cloudinary.utils.generate_auth_token(
+            start_time=1111111111,
+            duration=300,
+            url="http://res.cloudinary.com/test123/image/upload/v1486020273/sample.jpg"
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->
generate_auth_token should throw if acl or URL are not provided.

Currently, the function works, but the resulting signature is useless.

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[x] New feature
[ ] Bug fix
[ ] Adds more tests

#### Are tests included?
[x] Yes
[ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
