### PR TITLE
Return the stream position to the start of the file post-read

### DIFF
--- a/cloudinary/uploader.py
+++ b/cloudinary/uploader.py
@@ -433,6 +433,7 @@ def call_api(action, params, http_headers=None, return_error=False, unsigned=Fal
                 # stream
                 data = file.read()
                 name = filename or (file.name if hasattr(file, 'name') and isinstance(file.name, str) else "stream")
+                file.seek(0)
             elif isinstance(file, tuple):
                 name, data = file
             else:

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -202,6 +202,20 @@ class UploaderTest(unittest.TestCase):
         self.assertEqual(os.path.splitext(custom_filename)[0], result["original_filename"])
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
+    def test_upload_file_returns_stream_position(self):
+        """Should not mutate the BytesIO object after upload"""
+
+        with io.BytesIO() as temp_file, open(TEST_IMAGE, 'rb') as input_file:
+            temp_file.write(input_file.read())
+            temp_file.seek(0)
+
+            result = uploader.upload(temp_file, tags=[UNIQUE_TAG])
+        
+        empty_bytes_string = b''
+        file_data = temp_file.read()
+        self.assertNotEqual(file_data, empty_bytes_string)
+
+    @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_upload_filename_override(self):
         """should successfully override original_filename"""
 


### PR DESCRIPTION
### Brief Summary of Changes

Having used the Cloudinary SDK in a professional project I recently noticed that the `cloudinary.uploader.upload` method slightly mutates the file object provided to it. Specifically it leaves the stream position at the end of the file after uploading the data. 

This, in my opinion, is an unwanted side-effect and unfortunately caused a bug in previous code. A caller of this method would reasonably assume the file argument passed to such method remains identical and so could be used in the same way in the future regardless of whether it has been used by the cloudinary SDK prior.

I would be keen to hear your thoughts on what you think the desired behaviour should be :)

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[ ] New feature
[x] Bug fix
[ ] Adds more tests

#### Are tests included?
[ ] Yes
[x] No