### PR TITLE
Allow to disable b-frames for video codec `vc` on API

### DIFF
--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -530,9 +530,7 @@ def process_video_codec_param(param):
             out_param = out_param + ':' + param['profile']
             if 'level' in param:
                 out_param = out_param + ':' + param['level']
-                if 'b_frames' not in param or param['b_frames'] is True:
-                    pass
-                elif 'b_frames' in param and param['b_frames'] is False:
+                if param.get('b_frames') is False:
                     out_param = out_param + ':' + 'bframes_no'
 
     return out_param

--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -530,6 +530,11 @@ def process_video_codec_param(param):
             out_param = out_param + ':' + param['profile']
             if 'level' in param:
                 out_param = out_param + ':' + param['level']
+                if 'b_frames' not in param or param['b_frames'] is True:
+                    pass
+                elif 'b_frames' in param and param['b_frames'] is False:
+                    out_param = out_param + ':' + 'bframes_no'
+
     return out_param
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -794,7 +794,13 @@ class TestUtils(unittest.TestCase):
                                                                                   'level': '3.1'}},
                                    expected_url=VIDEO_UPLOAD_PATH + "vc_h264:basic:3.1/video_id")
 
-        # should support a b_frame parameter - b_frames=False -> bframes_no
+        # b_frames=True -> should not add b_frames parameter
+        self.__test_cloudinary_url(public_id="video_id", options={'resource_type': 'video',
+                                                                  'video_codec': {'codec': 'h265', 'profile': 'auto',
+                                                                                  'level': 'auto', 'b_frames': True}},
+                                   expected_url=VIDEO_UPLOAD_PATH + "vc_h265:auto:auto/video_id")
+
+        # should support a b_frames parameter - b_frames=False -> bframes_no
         self.__test_cloudinary_url(public_id="video_id", options={'resource_type': 'video',
                                                                   'video_codec': {'codec': 'h265', 'profile': 'auto',
                                                                                   'level': 'auto', 'b_frames': False}},

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -794,6 +794,12 @@ class TestUtils(unittest.TestCase):
                                                                                   'level': '3.1'}},
                                    expected_url=VIDEO_UPLOAD_PATH + "vc_h264:basic:3.1/video_id")
 
+        # should support a b_frame parameter - b_frames=False -> bframes_no
+        self.__test_cloudinary_url(public_id="video_id", options={'resource_type': 'video',
+                                                                  'video_codec': {'codec': 'h265', 'profile': 'auto',
+                                                                                  'level': 'auto', 'b_frames': False}},
+                                   expected_url=VIDEO_UPLOAD_PATH + "vc_h265:auto:auto:bframes_no/video_id")
+
     def test_audio_codec(self):
         # should support a string value
         self.__test_cloudinary_url(public_id="video_id", options={'resource_type': 'video', 'audio_codec': 'acc'},


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
