### PR TITLE
Options passed to the Django CloudinaryField can be callable

### DIFF
--- a/cloudinary/models.py
+++ b/cloudinary/models.py
@@ -106,7 +106,7 @@ class CloudinaryField(models.Field):
         value = super(CloudinaryField, self).pre_save(model_instance, add)
         if isinstance(value, UploadedFile):
             options = {"type": self.type, "resource_type": self.resource_type}
-            options.update(self.options)
+            options.update({key: val(model_instance) if callable(val) else val for key, val in self.options.items()})
             if hasattr(value, 'seekable') and value.seekable():
                 value.seek(0)
             instance_value = uploader.upload_resource(value, **options)

--- a/django_tests/test_cloudinaryField.py
+++ b/django_tests/test_cloudinaryField.py
@@ -63,6 +63,22 @@ class TestCloudinaryField(TestCase):
         self.assertEqual(upload_mock.call_args[1]['use_filename'], 'true')
         self.assertEqual(upload_mock.call_args[1]['phash'], 'true')
 
+    def test_callable_upload_options(self):
+
+        def get_image_name(instance):
+            return instance.question
+
+        c = CloudinaryField('image', public_id=get_image_name)
+        c.set_attributes_from_name('image')
+        poll = Poll(question="question", image=SimpleUploadedFile(TEST_IMAGE, b''))
+
+        mocked_resource = cloudinary.CloudinaryResource(type="upload", public_id=TEST_IMAGE, resource_type="image")
+        with mock.patch('cloudinary.uploader.upload_resource', return_value=mocked_resource) as upload_mock:
+            c.pre_save(poll, None)
+
+        self.assertTrue(upload_mock.called)
+        self.assertEqual(upload_mock.call_args.kwargs['public_id'], 'question')
+
     def test_pre_save(self):
         c = CloudinaryField('image', width_field="image_width", height_field="image_height")
         c.set_attributes_from_name('image')


### PR DESCRIPTION
### Brief Summary of Changes
This PR offers an option to pass upload parameters as callable arguments to the `CloudinaryField` for Django models. The callable should accept a single argument, the model instance, and return the desired value for the upload parameter.

Currently, `CloudinaryField` only supports adding specific upload options on a per-field basis. But, for the project I'm working on, I needed to generate the file's `public_id` from the other fields of the model instance. I know that there's an alternative solution to this, i.e setting the file name before the upload and using the `use_filename=True` option. But using a callable argument to the field seems cleaner to me and can be used for other options as well (like `tags`, `context` etc). Django already has callable arguments for some fields (such as `FileField.upload_to`) so this is nothing new for Django users.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [X] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I ran the full test suite before pushing the changes and all the tests pass.
