### PR TITLE
Move static files to static/cloudinary

### DIFF
--- a/cloudinary/templates/cloudinary_includes.html
+++ b/cloudinary/templates/cloudinary_includes.html
@@ -1,14 +1,14 @@
 {% load static %}
 
-<script src="{% static "js/jquery.ui.widget.js" %}" type="text/javascript"></script>
-<script src="{% static "js/jquery.iframe-transport.js" %}" type="text/javascript"></script>
-<script src="{% static "js/jquery.fileupload.js" %}" type="text/javascript"></script>
-<script src="{% static "js/jquery.cloudinary.js" %}" type="text/javascript"></script>
+<script src="{% static "cloudinary/js/jquery.ui.widget.js" %}" type="text/javascript"></script>
+<script src="{% static "cloudinary/js/jquery.iframe-transport.js" %}" type="text/javascript"></script>
+<script src="{% static "cloudinary/js/jquery.fileupload.js" %}" type="text/javascript"></script>
+<script src="{% static "cloudinary/js/jquery.cloudinary.js" %}" type="text/javascript"></script>
 
 {% if processing %}
-<script src="{% static "js/load-image.all.min.js" %}" type="text/javascript"></script>
-<script src="{% static "js/canvas-to-blob.min.js" %}" type="text/javascript"></script>
-<script src="{% static "js/jquery.fileupload-process.js" %}" type="text/javascript"></script>
-<script src="{% static "js/jquery.fileupload-image.js" %}" type="text/javascript"></script>
-<script src="{% static "js/jquery.fileupload-validate.js" %}" type="text/javascript"></script>
+<script src="{% static "cloudinary/js/load-image.all.min.js" %}" type="text/javascript"></script>
+<script src="{% static "cloudinary/js/canvas-to-blob.min.js" %}" type="text/javascript"></script>
+<script src="{% static "cloudinary/js/jquery.fileupload-process.js" %}" type="text/javascript"></script>
+<script src="{% static "cloudinary/js/jquery.fileupload-image.js" %}" type="text/javascript"></script>
+<script src="{% static "cloudinary/js/jquery.fileupload-validate.js" %}" type="text/javascript"></script>
 {% endif %}

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-/bin/rm -rf cloudinary/static
-mkdir -p cloudinary/static
-cd cloudinary/static
+/bin/rm -rf cloudinary/static/cloudinary
+mkdir -p cloudinary/static/cloudinary
+cd cloudinary/static/cloudinary
 
 OPTIONS=
 


### PR DESCRIPTION
Django recommends [1] storing static files under a folder matching the app name,
eg. `my_app/static/my_app/example.jpg`.

Why is this useful? Because all static folders from all apps will be merged
into a unified static folder and file names might collide from different apps.

It is also useful to be able to tell which app shipped `js/jquery.ui.widget.js`
so that the `--ignore PATTERN` flag of the `collectstatic` command can
efficiently be targeted at certain apps.

[1] https://docs.djangoproject.com/en/4.0/howto/static-files/#configuring-static-files

### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [x] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.

One seemingly unrelated test fails, but it also fails on `master`:

```
ERROR: setUpClass (test.test_uploader.UploaderTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "pycloudinary/test/test_uploader.py", line 111, in setUpClass
    api.add_metadata_field({
  File "pycloudinary/cloudinary/api.py", line 536, in add_metadata_field
    return call_metadata_api("post", [], params, **options)
  File "pycloudinary/cloudinary/api_client/call_api.py", line 22, in call_metadata_api
    return call_json_api(method, uri, params, **options)
  File "pycloudinary/cloudinary/api_client/call_api.py", line 27, in call_json_api
    return _call_api(method, uri, body=data, headers={'Content-Type': 'application/json'}, **options)
  File "pycloudinary/cloudinary/api_client/call_api.py", line 53, in _call_api
    return execute_request(http_connector=_http,
  File "pycloudinary/cloudinary/api_client/execute_request.py", line 84, in execute_request
    raise exception_class("Error {0} - {1}".format(response.status, result["error"]["message"]))
cloudinary.exceptions.AuthorizationRequired: Error 401 - unknown api_key
```
