### PR TITLE
Add support for `use_asset_folder_as_public_id_prefix` as upload para…

### DIFF
--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -94,6 +94,7 @@ __SIMPLE_UPLOAD_PARAMS = [
     "proxy",
     "folder",
     "asset_folder",
+    "use_asset_folder_as_public_id_prefix",
     "overwrite",
     "moderation",
     "raw_convert",

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -250,13 +250,14 @@ class UploaderTest(unittest.TestCase):
         mocker.return_value = MOCK_RESPONSE
 
         fd_params = {"public_id_prefix": FD_PID_PREFIX, "asset_folder": ASSET_FOLDER, "display_name": DISPLAY_NAME,
-                     "use_filename_as_display_name": True, "folder": TEST_FOLDER}
+                     "use_filename_as_display_name": True, "folder": TEST_FOLDER, "use_asset_folder_as_public_id_prefix": True}
         uploader.upload(TEST_IMAGE, tags=[UNIQUE_TAG], **fd_params)
 
         self.assertEqual(FD_PID_PREFIX, get_param(mocker, "public_id_prefix"))
         self.assertEqual(ASSET_FOLDER, get_param(mocker, "asset_folder"))
         self.assertEqual(DISPLAY_NAME, get_param(mocker, "display_name"))
         self.assertEqual("1", get_param(mocker, "use_filename_as_display_name"))
+        self.assertEqual("1", get_param(mocker, "use_asset_folder_as_public_id_prefix"))
         self.assertEqual(TEST_FOLDER, get_param(mocker, "folder"))
 
     @patch('urllib3.request.RequestMethods.request')


### PR DESCRIPTION
…meter in APIs

### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
