### PR TITLE
Add OS name in User-Agent and CLI

### DIFF
--- a/cloudinary/__init__.py
+++ b/cloudinary/__init__.py
@@ -24,6 +24,7 @@ from cloudinary.http_client import HttpClient
 from cloudinary.compat import urlparse, parse_qs
 
 from platform import python_version
+from platform import platform as pf
 
 CERT_KWARGS = {
     'cert_reqs': 'CERT_REQUIRED',
@@ -40,7 +41,10 @@ API_VERSION = "v1_1"
 
 VERSION = "1.29.0"
 
-USER_AGENT = "CloudinaryPython/{} (Python {})".format(VERSION, python_version())
+OS_INFO = pf().lower()
+OS_INFO = OS_INFO.split("-")
+
+USER_AGENT = "CloudinaryPython/{} (Python {}/{})".format(VERSION, python_version(),OS_INFO[0].capitalize())
 """ :const: USER_AGENT """
 
 USER_PLATFORM = ""

--- a/django_tests/test_user_agent.py
+++ b/django_tests/test_user_agent.py
@@ -12,4 +12,4 @@ class TestUserAgent(TestCase):
         os_info = pf().lower()
         os_info = os_info.split("-")
 
-        six.assertRegex(self, agent, r'^CloudinaryPython\/\d\.\d+\.\d+ \(Python \d\.\d+\.\d+\/{}\)$'.format(os_info[0].capitalize()))
+        six.assertRegex(self, agent, r'^Django\/\d\.\d+\.?\d* CloudinaryPython\/\d\.\d+\.\d+ \(Python \d\.\d+\.\d+\/{}\)$'.format(os_info[0].capitalize()))

--- a/django_tests/test_user_agent.py
+++ b/django_tests/test_user_agent.py
@@ -2,10 +2,14 @@ import six
 from django.test import TestCase
 
 import cloudinary
+from platform import platform as pf
 
 
 class TestUserAgent(TestCase):
     def test_django_user_agent(self):
         agent = cloudinary.get_user_agent()
 
-        six.assertRegex(self, agent, r'^Django\/\d\.\d+\.?\d* CloudinaryPython\/\d\.\d+\.\d+ \(Python \d\.\d+\.\d+\)$')
+        os_info = pf().lower()
+        os_info = os_info.split("-")
+
+        six.assertRegex(self, agent, r'^CloudinaryPython\/\d\.\d+\.\d+ \(Python \d\.\d+\.\d+\/{}\)$'.format(os_info[0].capitalize()))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -14,6 +14,8 @@ from os.path import getsize
 import six
 from mock import patch
 
+from platform import platform as pf
+
 import cloudinary.utils
 from cloudinary import CL_BLANK
 from cloudinary.utils import (
@@ -895,7 +897,10 @@ class TestUtils(unittest.TestCase):
     def test_user_agent(self):
         with patch('cloudinary.USER_PLATFORM', ''):
             agent = cloudinary.get_user_agent()
-        six.assertRegex(self, agent, r'^CloudinaryPython\/\d\.\d+\.\d+ \(Python \d\.\d+\.\d+\)$')
+            os_info = pf().lower()
+            os_info = os_info.split("-")
+
+        six.assertRegex(self, agent, r'^CloudinaryPython\/\d\.\d+\.\d+ \(Python \d\.\d+\.\d+\/{}\)$'.format(os_info[0].capitalize()))
 
         platform = 'MyPlatform/1.2.3 (Test code)'
         with patch('cloudinary.USER_PLATFORM', platform):


### PR DESCRIPTION
### Brief Summary of Changes
Add the OS Name in the User-Agent; This includes the CLI which leverages PythonSDK.  OS name inclusion aids in identifying that the request is coming from a particular OS and should address to not inadvertently include the folder paths into the `public_id`. (Pull 12624). 

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
