### PR TITLE
Add support for `unique_display_name`and `asset_folder` parameters

### DIFF
--- a/cloudinary/api.py
+++ b/cloudinary/api.py
@@ -200,6 +200,12 @@ def update(public_id, **options):
         params["auto_tagging"] = str(options.get("auto_tagging"))
     if "access_control" in options:
         params["access_control"] = utils.json_encode(utils.build_list_of_dicts(options.get("access_control")))
+    if "asset_folder" in options:
+        params["asset_folder"] = options.get("asset_folder")
+    if "display_name" in options:
+        params["display_name"] = options.get("display_name")
+    if "unique_display_name" in options:
+        params["unique_display_name"] = options.get("unique_display_name")
 
     return call_api("post", uri, params, **options)
 

--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -95,6 +95,7 @@ __SIMPLE_UPLOAD_PARAMS = [
     "folder",
     "asset_folder",
     "use_asset_folder_as_public_id_prefix",
+    "unique_display_name",
     "overwrite",
     "moderation",
     "raw_convert",

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -790,6 +790,17 @@ class ApiTest(unittest.TestCase):
         with six.assertRaisesRegex(self, BadRequest, 'Illegal value'):
             api.update(API_TEST_ID, background_removal="illegal")
 
+    @patch('urllib3.request.RequestMethods.request')
+    @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
+    def test33_update_asset_folder(self, mocker):
+        """Should pass folder decoupling params """
+        mocker.return_value = MOCK_RESPONSE
+        api.update(API_TEST_ID, asset_folder="folder_new_update", display_name="new_display_name", unique_display_name=True)
+        self.assertEqual("folder_new_update", get_param(mocker, "asset_folder"))
+        self.assertEqual("new_display_name", get_param(mocker, "display_name"))
+        self.assertTrue(get_param(mocker, "unique_display_name"))
+
+
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     @unittest.skip("For this test to work, 'Auto-create folders' should be enabled in the Upload Settings, " +
                    "and the account should be empty of folders. " +


### PR DESCRIPTION
### Brief Summary of Changes
<!--
The `unique_display_name`and `asset_folder` parameters have been added to the Admin API Update method
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
