### PR TITLE
Add support for `clear_invalid` metadata parameter

### DIFF
--- a/cloudinary/api.py
+++ b/cloudinary/api.py
@@ -223,6 +223,8 @@ def update(public_id, **options):
         params["display_name"] = options.get("display_name")
     if "unique_display_name" in options:
         params["unique_display_name"] = options.get("unique_display_name")
+    if "clear_invalid" in options:
+        params["clear_invalid"] = options.get("clear_invalid")
 
     return call_api("post", uri, params, **options)
 

--- a/cloudinary/uploader.py
+++ b/cloudinary/uploader.py
@@ -168,7 +168,8 @@ def update_metadata(metadata, public_ids, **options):
         "timestamp": utils.now(),
         "metadata": utils.encode_context(metadata),
         "public_ids": utils.build_array(public_ids),
-        "type": options.get("type")
+        "type": options.get("type"),
+        "clear_invalid": options.get("clear_invalid")
     }
 
     return call_api("metadata", params, **options)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -812,6 +812,13 @@ class ApiTest(unittest.TestCase):
         self.assertEqual("new_display_name", get_param(mocker, "display_name"))
         self.assertTrue(get_param(mocker, "unique_display_name"))
 
+    @patch('urllib3.request.RequestMethods.request')
+    @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
+    def test34_update_clear_invalid(self, mocker):
+        """Should pass folder decoupling params """
+        mocker.return_value = MOCK_RESPONSE
+        api.update(API_TEST_ID, clear_invalid=True)
+        self.assertTrue(get_param(mocker, "clear_invalid"))
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     @unittest.skip("For this test to work, 'Auto-create folders' should be enabled in the Upload Settings, " +

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -459,6 +459,13 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
             "public_ids": public_ids,
         })
 
+    @patch('urllib3.request.RequestMethods.request')
+    @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
+    def test_clear_invalid(self, mocker):
+        mocker.return_value = MOCK_RESPONSE
+        uploader.update_metadata(METADATA_FIELDS, public_ids=[TEST_ID], clear_invalid=True)
+        self.assertTrue(get_param(mocker, "clear_invalid"))
+
     def test_upload_with_metadata(self):
         """Upload should support `metadata` parameter"""
         result = uploader.upload(TEST_IMAGE, tags=[UNIQUE_TAG], metadata=METADATA_FIELDS)


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [X] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I ran the full test suite before pushing the changes and all the tests pass.
