### PR TITLE
Add support for extra_headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,3 @@
-1.32.1 / 2023-03-28
-==================
-
-New functionality and features
-------------------------------
-
-  * Add support for `extra_headers` parameter in Upload and Admin API
-
 1.32.0 / 2023-02-09
 ==================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.32.1 / 2023-03-28
+==================
+
+New functionality and features
+------------------------------
+
+  * Add support for `extra_headers` parameter in Upload and Admin API
+
 1.32.0 / 2023-02-09
 ==================
 

--- a/cloudinary/api_client/call_api.py
+++ b/cloudinary/api_client/call_api.py
@@ -31,7 +31,7 @@ def call_api(method, uri, params, **options):
     return _call_api(method, uri, params=params, **options)
 
 
-def _call_api(method, uri, params=None, body=None, headers=None, **options):
+def _call_api(method, uri, params=None, body=None, headers=None, extra_headers=None, **options):
     prefix = options.pop("upload_prefix",
                          cloudinary.config().upload_prefix) or "https://api.cloudinary.com"
     cloud_name = options.pop("cloud_name", cloudinary.config().cloud_name)
@@ -49,6 +49,9 @@ def _call_api(method, uri, params=None, body=None, headers=None, **options):
 
     if body is not None:
         options["body"] = body
+
+    if extra_headers is not None:
+        headers.update(extra_headers)
 
     return execute_request(http_connector=_http,
                            method=method,

--- a/cloudinary/uploader.py
+++ b/cloudinary/uploader.py
@@ -472,13 +472,16 @@ def call_cacheable_api(action, params, http_headers=None, return_error=False, un
     return result
 
 
-def call_api(action, params, http_headers=None, return_error=False, unsigned=False, file=None, timeout=None, **options):
+def call_api(action, params, http_headers=None, return_error=False, unsigned=False, file=None, timeout=None, extra_headers=None, **options):
     params = utils.cleanup_params(params)
 
     headers = {"User-Agent": cloudinary.get_user_agent()}
 
     if http_headers is not None:
         headers.update(http_headers)
+
+    if extra_headers is not None:
+        headers.update(extra_headers)
 
     oauth_token = options.get("oauth_token", cloudinary.config().oauth_token)
 

--- a/cloudinary/uploader.py
+++ b/cloudinary/uploader.py
@@ -472,7 +472,8 @@ def call_cacheable_api(action, params, http_headers=None, return_error=False, un
     return result
 
 
-def call_api(action, params, http_headers=None, return_error=False, unsigned=False, file=None, timeout=None, extra_headers=None, **options):
+def call_api(action, params, http_headers=None, return_error=False, unsigned=False, file=None, timeout=None,
+             extra_headers=None, **options):
     params = utils.cleanup_params(params)
 
     headers = {"User-Agent": cloudinary.get_user_agent()}

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -293,7 +293,9 @@ class ApiTest(unittest.TestCase):
                                                                  'AppleWebKit/537.36 (KHTML, like Gecko) '
                                                                  'Chrome/58.0.3029.110 Safari/537.3'})
         headers = get_headers(mocker.call_args[0])
-        self.assertTrue(headers.get('User-Agent'))
+        self.assertEqual(headers.get('User-Agent'), 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' 
+                                                    'AppleWebKit/537.36 (KHTML, like Gecko) '
+                                                    'Chrome/58.0.3029.110 Safari/537.3')
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test07_resource_metadata(self):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -10,7 +10,7 @@ from urllib3 import disable_warnings, ProxyManager, PoolManager
 import cloudinary
 from cloudinary import api, uploader, utils
 from cloudinary.utils import fq_public_id
-from test.helper_test import SUFFIX, TEST_IMAGE, get_uri, get_params, get_list_param, get_param, TEST_DOC, get_method, \
+from test.helper_test import SUFFIX, TEST_IMAGE, get_uri, get_headers, get_params, get_list_param, get_param, TEST_DOC, get_method, \
     UNIQUE_TAG, api_response_mock, ignore_exception, cleanup_test_resources_by_tag, cleanup_test_transformation, \
     cleanup_test_resources, UNIQUE_TEST_FOLDER, EVAL_STR, get_json_body
 from cloudinary.exceptions import BadRequest, NotFound
@@ -283,6 +283,17 @@ class ApiTest(unittest.TestCase):
         args, kargs = mocker.call_args
         self.assertTrue(get_uri(args).endswith('/resources/image/tags/{}'.format(API_TEST_TAG)))
         self.assertEqual(get_params(args)['direction'], 'desc')
+
+    @patch('urllib3.request.RequestMethods.request')
+    @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
+    def test_extra_headers(self, mocker):
+        """Should support extra headers"""
+        mocker.return_value = MOCK_RESPONSE
+        uploader.upload(TEST_IMAGE, extra_headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                                                                 'AppleWebKit/537.36 (KHTML, like Gecko) '
+                                                                 'Chrome/58.0.3029.110 Safari/537.3'})
+        headers = get_headers(mocker.call_args[0])
+        self.assertTrue(headers.get('User-Agent'))
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test07_resource_metadata(self):

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -16,7 +16,7 @@ from cloudinary.cache import responsive_breakpoints_cache
 from cloudinary.cache.adapter.key_value_cache_adapter import KeyValueCacheAdapter
 from cloudinary.compat import urlparse, parse_qs
 from test.cache.storage.dummy_cache_storage import DummyCacheStorage
-from test.helper_test import uploader_response_mock, SUFFIX, TEST_IMAGE, get_params, TEST_ICON, TEST_DOC, \
+from test.helper_test import uploader_response_mock, SUFFIX, TEST_IMAGE, get_params, get_headers, TEST_ICON, TEST_DOC, \
     REMOTE_TEST_IMAGE, UTC, populate_large_file, TEST_UNICODE_IMAGE, get_uri, get_method, get_param, \
     cleanup_test_resources_by_tag, cleanup_test_transformation, cleanup_test_resources, EVAL_STR
 from test.test_utils import TEST_ID, TEST_FOLDER
@@ -514,12 +514,17 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         uploader.upload(TEST_IMAGE, headers=["Link: 1"], tags=[UNIQUE_TAG])
         uploader.upload(TEST_IMAGE, headers={"Link": "1"}, tags=[UNIQUE_TAG])
 
+    @patch('urllib3.request.RequestMethods.request')
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
-    def test_extra_headers(self):
+    def test_extra_headers(self, mocker):
         """Should support extra headers"""
+        mocker.return_value = MOCK_RESPONSE
         uploader.upload(TEST_IMAGE, extra_headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
                                                                  'AppleWebKit/537.36 (KHTML, like Gecko) '
                                                                  'Chrome/58.0.3029.110 Safari/537.3'})
+        headers = get_headers(mocker.call_args[0])
+        print("headers", headers)
+        self.assertTrue(headers.get('User-Agent'))
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_text(self):

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -523,7 +523,9 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
                                                                  'AppleWebKit/537.36 (KHTML, like Gecko) '
                                                                  'Chrome/58.0.3029.110 Safari/537.3'})
         headers = get_headers(mocker.call_args[0])
-        self.assertTrue(headers.get('User-Agent'))
+        self.assertEqual(headers.get('User-Agent'), 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' 
+                                                    'AppleWebKit/537.36 (KHTML, like Gecko) '
+                                                    'Chrome/58.0.3029.110 Safari/537.3')
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_text(self):

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -508,6 +508,13 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         uploader.upload(TEST_IMAGE, headers={"Link": "1"}, tags=[UNIQUE_TAG])
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
+    def test_extra_headers(self):
+        """Should support extra headers"""
+        uploader.upload(TEST_IMAGE, extra_headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                                                                 'AppleWebKit/537.36 (KHTML, like Gecko) '
+                                                                 'Chrome/58.0.3029.110 Safari/537.3'})
+
+    @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_text(self):
         """Should successfully generate text image """
         result = uploader.text("hello world", public_id=TEXT_ID)

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -523,7 +523,6 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
                                                                  'AppleWebKit/537.36 (KHTML, like Gecko) '
                                                                  'Chrome/58.0.3029.110 Safari/537.3'})
         headers = get_headers(mocker.call_args[0])
-        print("headers", headers)
         self.assertTrue(headers.get('User-Agent'))
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")


### PR DESCRIPTION
### Brief Summary of Changes
Adds support for `extra_headers` in uploader.py and adds tests in `test_uploader.py`

Adds support for `extra_headers` in `call_api.py`

Adds line in ChangeLog for changes.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [X] Adds more tests

#### Are tests included?
- [X] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I ran the full test suite before pushing the changes and all the tests pass.
