### PR TITLE
Add support for `target_asset_folder` API parameter

### DIFF
--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -1008,6 +1008,7 @@ def archive_params(**options):
         "skip_transformation_name": options.get("skip_transformation_name"),
         "tags": options.get("tags") and build_array(options.get("tags")),
         "target_format": options.get("target_format"),
+        "target_asset_folder": options.get("target_asset_folder"),
         "target_public_id": options.get("target_public_id"),
         "target_tags": options.get("target_tags") and build_array(options.get("target_tags")),
         "timestamp": timestamp,

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -1076,6 +1076,11 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         self.assertIn("timestamp", parameters)
         self.assertIn("signature", parameters)
 
+    @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
+    def test_create_zip_with_target_asset_folder(self):
+        """Should pass target_asset_folder parameter on archive generation"""
+        create_zip_res = uploader.create_zip(tags="test-tag", target_asset_folder="test-asset-folder")
+        self.assertEqual("test-asset-folder", create_zip_res.get("asset_folder"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -1076,11 +1076,13 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         self.assertIn("timestamp", parameters)
         self.assertIn("signature", parameters)
 
+    @patch('urllib3.request.RequestMethods.request')
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
-    def test_create_zip_with_target_asset_folder(self):
+    def test_create_zip_with_target_asset_folder(self, mocker):
         """Should pass target_asset_folder parameter on archive generation"""
-        create_zip_res = uploader.create_zip(tags="test-tag", target_asset_folder="test-asset-folder")
-        self.assertEqual("test-asset-folder", create_zip_res.get("asset_folder"))
+        mocker.return_value = MOCK_RESPONSE
+        uploader.create_zip(tags="test-tag", target_asset_folder="test-asset-folder")
+        self.assertEqual("test-asset-folder", get_param(mocker, "target_asset_folder"))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Brief Summary of Changes
Cloudinary API supports the `target_asset_folder` parameter (relevant for clouds with Dynamic Folders mode enabled) for Archive Generation requests but this parameter is not whitelisted within the SDK so it gets discarded if passed currently.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [X] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I ran the full test suite before pushing the changes and all the tests pass.
