### PR TITLE
Add support for `on_success` upload parameter

### DIFF
--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -92,6 +92,7 @@ __SIMPLE_UPLOAD_PARAMS = [
     "eager_notification_url",
     "eager_async",
     "eval",
+    "on_success",
     "proxy",
     "folder",
     "asset_folder",

--- a/test/helper_test.py
+++ b/test/helper_test.py
@@ -41,6 +41,7 @@ ZERO = timedelta(0)
 EVAL_STR = 'if (resource_info["width"] < 450) { upload_options["quality_analysis"] = true }; ' \
            'upload_options["context"] = "width=" + resource_info["width"]'
 
+ON_SUCCESS_STR = 'current_asset.update({tags: ["autocaption"]});'
 
 class UTC(tzinfo):
     """UTC"""

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -427,13 +427,6 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_explicit(self):
-        """Should support explicit """
-        result = uploader.explicit("cloudinary", type="twitter_name", eager=[TEST_TRANS_SCALE2_PNG], tags=[UNIQUE_TAG])
-        params = dict(TEST_TRANS_SCALE2_PNG, type="twitter_name", version=result["version"])
-        url = utils.cloudinary_url("cloudinary", **params)[0]
-        actual = result["eager"][0]["url"]
-        self.assertEqual(parse_url(actual).path, parse_url(url).path)
-
         # Test explicit with metadata
         resource = uploader.upload(TEST_IMAGE, tags=[UNIQUE_TAG])
         result_metadata = uploader.explicit(resource['public_id'], type="upload", metadata=METADATA_FIELDS,

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -18,7 +18,7 @@ from cloudinary.compat import urlparse, parse_qs
 from test.cache.storage.dummy_cache_storage import DummyCacheStorage
 from test.helper_test import uploader_response_mock, SUFFIX, TEST_IMAGE, get_params, get_headers, TEST_ICON, TEST_DOC, \
     REMOTE_TEST_IMAGE, UTC, populate_large_file, TEST_UNICODE_IMAGE, get_uri, get_method, get_param, \
-    cleanup_test_resources_by_tag, cleanup_test_transformation, cleanup_test_resources, EVAL_STR
+    cleanup_test_resources_by_tag, cleanup_test_transformation, cleanup_test_resources, EVAL_STR, ON_SUCCESS_STR
 from test.test_utils import TEST_ID, TEST_FOLDER
 
 MOCK_RESPONSE = uploader_response_mock()
@@ -958,6 +958,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
             'accessibility_analysis': True,
             'media_metadata': True,
             'visual_search': True,
+            'on_success': ON_SUCCESS_STR
         }
 
         uploader.upload(TEST_IMAGE, **options)
@@ -971,7 +972,6 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         params = get_params(request_mock.call_args[0])
         for param in options.keys():
             self.assertIn(param, params)
-
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_eval_upload_parameter(self):


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
