### PR TITLE
Add support for `urllib3` version `2.0`

### DIFF
--- a/cloudinary/api_client/execute_request.py
+++ b/cloudinary/api_client/execute_request.py
@@ -63,9 +63,8 @@ def execute_request(http_connector, method, params, headers, auth, api_url, **op
     processed_params = process_params(params)
 
     api_url = smart_escape(unquote(api_url))
-
     try:
-        response = http_connector.request(method.upper(), api_url, processed_params, req_headers, **kw)
+        response = http_connector.request(method=method.upper(), url=api_url, fields=processed_params, headers=req_headers, **kw)
         body = response.data
     except HTTPError as e:
         raise GeneralError("Unexpected error %s" % str(e))

--- a/cloudinary/http_client.py
+++ b/cloudinary/http_client.py
@@ -24,7 +24,7 @@ class HttpClient:
 
     def get_json(self, url):
         try:
-            response = self._http_client.request("GET", url, timeout=self.timeout)
+            response = self._http_client.request(method="GET", url=url, timeout=self.timeout)
             body = response.data
         except HTTPError as e:
             raise GeneralError("Unexpected error %s" % str(e))

--- a/cloudinary/uploader.py
+++ b/cloudinary/uploader.py
@@ -506,7 +506,7 @@ def call_api(action, params, http_headers=None, return_error=False, unsigned=Fal
 
     code = 200
     try:
-        response = _http.request("POST", api_url, param_list, headers, **kw)
+        response = _http.request(method="POST", url=api_url, fields=param_list, headers=headers, **kw)
     except HTTPError as e:
         raise Error("Unexpected error - {0!r}".format(e))
     except socket.error as e:

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(name='cloudinary',
       test_suite="test",
       install_requires=[
           "six",
-          "urllib3>=1.26.5,<2",
+          "urllib3>=1.26.5",
           "certifi"
       ],
       tests_require=[

--- a/test/test_api_authorization.py
+++ b/test/test_api_authorization.py
@@ -6,7 +6,7 @@ from mock import patch
 import cloudinary
 from cloudinary import api
 from cloudinary import uploader
-from test.helper_test import TEST_IMAGE, get_headers, get_params
+from test.helper_test import TEST_IMAGE, get_headers, get_params, URLLIB3_REQUEST
 from test.test_api import MOCK_RESPONSE
 from test.test_config import OAUTH_TOKEN, CLOUD_NAME, API_KEY, API_SECRET
 from test.test_uploader import API_TEST_PRESET
@@ -16,45 +16,42 @@ class ApiAuthorizationTest(unittest.TestCase):
     def setUp(self):
         self.config = cloudinary.config(cloud_name=CLOUD_NAME, api_key=API_KEY, api_secret=API_SECRET)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_oauth_token_admin_api(self, mocker):
         self.config.oauth_token = OAUTH_TOKEN
         mocker.return_value = MOCK_RESPONSE
 
         api.ping()
 
-        args, _ = mocker.call_args
-        headers = get_headers(args)
+        headers = get_headers(mocker)
 
         self.assertTrue("authorization" in headers)
         self.assertEqual("Bearer {}".format(OAUTH_TOKEN), headers["authorization"])
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_oauth_token_as_an_option_admin_api(self, mocker):
         mocker.return_value = MOCK_RESPONSE
 
         api.ping(oauth_token=OAUTH_TOKEN)
 
-        args, _ = mocker.call_args
-        headers = get_headers(args)
+        headers = get_headers(mocker)
 
         self.assertTrue("authorization" in headers)
         self.assertEqual("Bearer {}".format(OAUTH_TOKEN), headers["authorization"])
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_key_and_secret_admin_api(self, mocker):
         self.config.oauth_token = None
         mocker.return_value = MOCK_RESPONSE
 
         api.ping()
 
-        args, _ = mocker.call_args
-        headers = get_headers(args)
+        headers = get_headers(mocker)
 
         self.assertTrue("authorization" in headers)
         self.assertEqual("Basic a2V5OnNlY3JldA==", headers["authorization"])
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_missing_credentials_admin_api(self, mocker):
         self.config.oauth_token = None
         self.config.api_key = None
@@ -65,49 +62,47 @@ class ApiAuthorizationTest(unittest.TestCase):
         with six.assertRaisesRegex(self, Exception, "Must supply api_key"):
             api.ping()
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_oauth_token_upload_api(self, mocker):
         self.config.oauth_token = OAUTH_TOKEN
         mocker.return_value = MOCK_RESPONSE
 
         uploader.upload(TEST_IMAGE)
 
-        args, _ = mocker.call_args
-        headers = get_headers(args)
+        headers = get_headers(mocker)
 
         self.assertTrue("authorization" in headers)
         self.assertEqual("Bearer {}".format(OAUTH_TOKEN), headers["authorization"])
 
-        params = get_params(args)
+        params = get_params(mocker)
         self.assertNotIn("signature", params)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_oauth_token_as_an_option_upload_api(self, mocker):
         mocker.return_value = MOCK_RESPONSE
 
         uploader.upload(TEST_IMAGE, oauth_token=OAUTH_TOKEN)
 
-        headers = get_headers(mocker.call_args[0])
+        headers = get_headers(mocker)
 
         self.assertTrue("authorization" in headers)
         self.assertEqual("Bearer {}".format(OAUTH_TOKEN), headers["authorization"])
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_key_and_secret_upload_api(self, mocker):
         self.config.oauth_token = None
         mocker.return_value = MOCK_RESPONSE
 
         uploader.upload(TEST_IMAGE)
 
-        args, _ = mocker.call_args
-        headers = get_headers(args)
+        headers = get_headers(mocker)
         self.assertNotIn("authorization", headers)
 
-        params = get_params(args)
+        params = get_params(mocker)
         self.assertIn("signature", params)
         self.assertIn("api_key", params)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_missing_credentials_upload_api(self, mocker):
         self.config.oauth_token = None
         self.config.api_key = None
@@ -122,7 +117,7 @@ class ApiAuthorizationTest(unittest.TestCase):
         uploader.unsigned_upload(TEST_IMAGE, upload_preset=API_TEST_PRESET)
 
         args, _ = mocker.call_args
-        params = get_params(args)
+        params = get_params(mocker)
         self.assertTrue("upload_preset" in params)
 
 

--- a/test/test_archive.py
+++ b/test/test_archive.py
@@ -15,7 +15,7 @@ import urllib3
 from urllib3 import disable_warnings
 
 from test.helper_test import SUFFIX, TEST_IMAGE, api_response_mock, cleanup_test_resources_by_tag, UNIQUE_TEST_ID, \
-    get_uri, get_list_param, get_params
+    get_uri, get_list_param, get_params, URLLIB3_REQUEST
 
 MOCK_RESPONSE = api_response_mock()
 
@@ -48,7 +48,7 @@ class ArchiveTest(unittest.TestCase):
             tags=[TEST_TAG], transformations=[{"width": 0.5}, {"width": 2.0}], target_tags=[TEST_TAG_RAW])
         self.assertEqual(4, result2.get("file_count"))
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_optional_parameters(self, mocker):
         """should allow optional parameters"""
@@ -60,7 +60,7 @@ class ArchiveTest(unittest.TestCase):
             allow_missing=True,
             skip_transformation_name=True,
         )
-        params = get_params(mocker.call_args[0])
+        params = get_params(mocker)
         self.assertEqual(params['expires_at'], expires_at)
         self.assertTrue(params['allow_missing'])
         self.assertTrue(params['skip_transformation_name'])
@@ -114,7 +114,7 @@ class ArchiveTest(unittest.TestCase):
         download_folder_url = utils.download_folder(folder_path="folder/", use_original_filename=True)
         self.assertIn("use_original_filename", download_folder_url)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_create_archive_multiple_resource_types(self, mocker):
         """should allow fully_qualified_public_ids"""
@@ -131,9 +131,7 @@ class ArchiveTest(unittest.TestCase):
             fully_qualified_public_ids=test_ids
         )
 
-        args, kargs = mocker.call_args
-
-        self.assertTrue(get_uri(args).endswith('/auto/generate_archive'))
+        self.assertTrue(get_uri(mocker).endswith('/auto/generate_archive'))
         self.assertEqual(test_ids, get_list_param(mocker, 'fully_qualified_public_ids'))
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")

--- a/test/test_cloudinary_resource.py
+++ b/test/test_cloudinary_resource.py
@@ -6,7 +6,8 @@ from urllib3 import disable_warnings
 import cloudinary
 from cloudinary import CloudinaryResource
 from cloudinary import uploader
-from test.helper_test import SUFFIX, TEST_IMAGE, http_response_mock, get_request_url, cleanup_test_resources_by_tag
+from test.helper_test import SUFFIX, TEST_IMAGE, http_response_mock, get_uri, cleanup_test_resources_by_tag, \
+    URLLIB3_REQUEST
 
 disable_warnings()
 
@@ -76,16 +77,16 @@ class TestCloudinaryResource(TestCase):
         self.assertNotIn(' src="{url}'.format(url=self.res.build_url(width="auto", crop="scale")), image)
         self.assertIn('data-src="{url}'.format(url=self.res.build_url(width="auto", crop="scale")), image)
 
-    @mock.patch('urllib3.request.RequestMethods.request', return_value=mocked_response)
+    @mock.patch(URLLIB3_REQUEST, return_value=mocked_response)
     def test_fetch_breakpoints(self, mocked_request):
         """Should retrieve responsive breakpoints from cloudinary resource (mocked)"""
         actual_breakpoints = self.res._fetch_breakpoints()
 
         self.assertEqual(self.mocked_breakpoints, actual_breakpoints)
 
-        self.assertIn(self.expected_transformation, get_request_url(mocked_request))
+        self.assertIn(self.expected_transformation, get_uri(mocked_request))
 
-    @mock.patch('urllib3.request.RequestMethods.request', return_value=mocked_response)
+    @mock.patch(URLLIB3_REQUEST, return_value=mocked_response)
     def test_fetch_breakpoints_with_transformation(self, mocked_request):
         """Should retrieve responsive breakpoints from cloudinary resource with custom transformation (mocked)"""
         srcset = {"transformation": self.crop_transformation}
@@ -94,7 +95,7 @@ class TestCloudinaryResource(TestCase):
         self.assertEqual(self.mocked_breakpoints, actual_breakpoints)
 
         self.assertIn(self.crop_transformation_str + "/" + self.expected_transformation,
-                      get_request_url(mocked_request))
+                      get_uri(mocked_request))
 
     def test_fetch_breakpoints_real(self):
         """Should retrieve responsive breakpoints from cloudinary resource (real request)"""

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -140,7 +140,7 @@ class ImageTest(unittest.TestCase):
         six.assertRegex(self, tag, expected_re)
 
     def _common_image_tag_helper(self, tag_name, public_id, common_trans_str, custom_trans_str=None,
-                                srcset_breakpoints=None, attributes=None, is_void=False):
+                                 srcset_breakpoints=None, attributes=None, is_void=False):
         """
         Helper method for generating expected img and source tags
 
@@ -342,14 +342,14 @@ class ImageTest(unittest.TestCase):
     def test_srcset_invalid_values(self):
         """Should raise ValueError on invalid values"""
         invalid_srcset_params = [
-            {'sizes': True},                                          # srcset data not provided
-            {'max_width': 300, 'max_images': 3},                      # no min_width
-            {'min_width': '1', 'max_width': 300, 'max_images': 3},    # invalid min_width
-            {'min_width': 100, 'max_images': 3},                      # no max_width
-            {'min_width': 100, 'max_width': '3', 'max_images': 3},    # invalid max_width
-            {'min_width': 200, 'max_width': 100, 'max_images': 3},    # min_width > max_width
-            {'min_width': 100, 'max_width': 300},                     # no max_images
-            {'min_width': 100, 'max_width': 300, 'max_images': 0},    # invalid max_images
+            {'sizes': True},  # srcset data not provided
+            {'max_width': 300, 'max_images': 3},  # no min_width
+            {'min_width': '1', 'max_width': 300, 'max_images': 3},  # invalid min_width
+            {'min_width': 100, 'max_images': 3},  # no max_width
+            {'min_width': 100, 'max_width': '3', 'max_images': 3},  # invalid max_width
+            {'min_width': 200, 'max_width': 100, 'max_images': 3},  # min_width > max_width
+            {'min_width': 100, 'max_width': 300},  # no max_images
+            {'min_width': 100, 'max_width': 300, 'max_images': 0},  # invalid max_images
             {'min_width': 100, 'max_width': 300, 'max_images': -17},  # invalid max_images
             {'min_width': 100, 'max_width': 300, 'max_images': '3'},  # invalid max_images
         ]
@@ -402,7 +402,7 @@ class ImageTest(unittest.TestCase):
         media = {"min_width": self.min_width, "max_width": self.max_width}
         tag = CloudinaryImage(self.full_public_id).source(media=media)
         expected_media = "(min-width: {min}px) and (max-width: {max}px)".format(min=self.min_width,
-                                                                                     max=self.max_width)
+                                                                                max=self.max_width)
         expected_tag = self._get_expected_cl_source_tag(self.full_public_id, "", attributes={"media": expected_media})
 
         self.assertEqual(expected_tag, tag)

--- a/test/test_provisioning_api.py
+++ b/test/test_provisioning_api.py
@@ -8,7 +8,7 @@ import cloudinary.provisioning.account
 from cloudinary.provisioning import account_config, reset_config
 from cloudinary.exceptions import AuthorizationRequired, NotFound
 
-from test.helper_test import UNIQUE_SUB_ACCOUNT_ID
+from test.helper_test import UNIQUE_SUB_ACCOUNT_ID, UNIQUE_TEST_ID
 
 disable_warnings()
 
@@ -212,27 +212,35 @@ class AccountApiTest(unittest.TestCase):
     def test_get_access_keys(self):
         res = cloudinary.provisioning.access_keys(self.cloud_id)
 
-        self.assertEqual(1, res["total"])
-        self.assertEqual(1, len(res["access_keys"]))
+        self.assertGreater(res["total"], 0)
+        self.assertGreater(len(res["access_keys"]), 0)
 
     @unittest.skipUnless(cloudinary.provisioning.account_config().provisioning_api_secret,
                          "requires provisioning_api_key/provisioning_api_secret")
     def test_generate_access_key(self):
-        res = cloudinary.provisioning.generate_access_key(self.cloud_id, name="test_key", enabled=False)
+        key_name = UNIQUE_TEST_ID + "_test_key"
+        res = cloudinary.provisioning.generate_access_key(self.cloud_id, name=key_name, enabled=False)
 
-        self.assertEqual("test_key", res["name"])
+        self.assertEqual(key_name, res["name"])
         self.assertEqual(False, res["enabled"])
 
     @unittest.skipUnless(cloudinary.provisioning.account_config().provisioning_api_secret,
                          "requires provisioning_api_key/provisioning_api_secret")
     def test_update_access_key(self):
-        key_res = cloudinary.provisioning.generate_access_key(self.cloud_id, name="test_key", enabled=False)
+        key_name = UNIQUE_TEST_ID + "_before_update_test_key"
+        updated_key_name = UNIQUE_TEST_ID + "_updated_test_key"
+
+        key_res = cloudinary.provisioning.generate_access_key(self.cloud_id, name=key_name, enabled=True)
+
+        self.assertEqual(key_name, key_res["name"])
+        self.assertEqual(True, key_res["enabled"])
 
         res = cloudinary.provisioning.update_access_key(self.cloud_id, key_res["api_key"],
-                                                        name="updated_key", enabled=True)
+                                                        name=updated_key_name, enabled=False)
 
-        self.assertEqual("updated_key", res["name"])
-        self.assertEqual(True, res["enabled"])
+        self.assertEqual(updated_key_name, res["name"])
+        self.assertEqual(False, res["enabled"])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -10,7 +10,7 @@ from urllib3 import disable_warnings
 import cloudinary
 from cloudinary import uploader, SearchFolders, Search
 from test.helper_test import SUFFIX, TEST_IMAGE, TEST_TAG, UNIQUE_TAG, TEST_FOLDER, UNIQUE_TEST_FOLDER, \
-    retry_assertion, cleanup_test_resources_by_tag
+    retry_assertion, cleanup_test_resources_by_tag, URLLIB3_REQUEST, get_json_body, get_uri
 from test.test_api import MOCK_RESPONSE, NEXT_CURSOR
 from test.test_config import CLOUD_NAME, API_KEY, API_SECRET
 
@@ -202,7 +202,7 @@ class SearchTest(unittest.TestCase):
             self.assertTrue('image_metadata' in res)
             self.assertEqual(len(res['tags']), 2)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_should_not_duplicate_values(self, mocker):
         mocker.return_value = MOCK_RESPONSE
 
@@ -308,7 +308,7 @@ class SearchTest(unittest.TestCase):
             search.to_url(ttl=300, next_cursor="")
         )
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_should_search_folders_endpoint(self, mocker):
         mocker.return_value = MOCK_RESPONSE
 
@@ -316,11 +316,9 @@ class SearchTest(unittest.TestCase):
             .expression(FOLDERS_SEARCH_EXPRESSION) \
             .execute()
 
-        args, kwargs = mocker.call_args
-        url = args[1]
-        result = json.loads(kwargs['body'])
+        result = get_json_body(mocker)
 
-        self.assertTrue(url.endswith('folders/search'))
+        self.assertTrue(get_uri(mocker).endswith('folders/search'))
 
         self.assertEqual({'expression': FOLDERS_SEARCH_EXPRESSION}, result)
 

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -18,7 +18,8 @@ from cloudinary.compat import urlparse, parse_qs
 from test.cache.storage.dummy_cache_storage import DummyCacheStorage
 from test.helper_test import uploader_response_mock, SUFFIX, TEST_IMAGE, get_params, get_headers, TEST_ICON, TEST_DOC, \
     REMOTE_TEST_IMAGE, UTC, populate_large_file, TEST_UNICODE_IMAGE, get_uri, get_method, get_param, \
-    cleanup_test_resources_by_tag, cleanup_test_transformation, cleanup_test_resources, EVAL_STR, ON_SUCCESS_STR
+    cleanup_test_resources_by_tag, cleanup_test_transformation, cleanup_test_resources, EVAL_STR, ON_SUCCESS_STR, \
+    URLLIB3_REQUEST
 from test.test_utils import TEST_ID, TEST_FOLDER
 
 MOCK_RESPONSE = uploader_response_mock()
@@ -241,7 +242,7 @@ class UploaderTest(unittest.TestCase):
 
         self.assertEqual('overridden', result["original_filename"])
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_upload_async(self, mocker):
         """Should pass async value """
@@ -250,7 +251,7 @@ class UploaderTest(unittest.TestCase):
         uploader.upload(TEST_IMAGE, tags=[UNIQUE_TAG], **async_option)
         self.assertTrue(get_param(mocker, 'async'))
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_upload_folder_decoupling(self, mocker):
         """Should pass folder decoupling params """
@@ -267,14 +268,14 @@ class UploaderTest(unittest.TestCase):
         self.assertEqual("1", get_param(mocker, "use_asset_folder_as_public_id_prefix"))
         self.assertEqual(TEST_FOLDER, get_param(mocker, "folder"))
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_ocr(self, mocker):
         """Should pass ocr value """
         mocker.return_value = MOCK_RESPONSE
         uploader.upload(TEST_IMAGE, tags=[UNIQUE_TAG], ocr='adv_ocr')
-        args, kargs = mocker.call_args
-        self.assertEqual(get_params(args)['ocr'], 'adv_ocr')
+        
+        self.assertEqual(get_params(mocker)['ocr'], 'adv_ocr')
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_quality_analysis(self):
@@ -298,7 +299,7 @@ class UploaderTest(unittest.TestCase):
         self.assertIn("focus", result["quality_analysis"])
         self.assertIsInstance(result["quality_analysis"]["focus"], float)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_quality_override(self, mocker):
         """Should pass quality_override """
@@ -378,44 +379,44 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         uploader.rename(result2["public_id"], result["public_id"] + "2", overwrite=True)
         self.assertEqual(api.resource(result["public_id"] + "2")["format"], "ico")
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_rename_parameters(self, mocker):
         """Should support to_type, invalidate, and overwrite """
         mocker.return_value = MOCK_RESPONSE
         uploader.rename(TEST_IMAGE, TEST_IMAGE + "2", to_type='raw', invalidate=True, overwrite=False)
-        args, kargs = mocker.call_args
-        self.assertEqual(get_params(args)['to_type'], 'raw')
-        self.assertTrue(get_params(args)['invalidate'])
-        self.assertTrue(get_params(args)['overwrite'])
+        
+        self.assertEqual(get_params(mocker)['to_type'], 'raw')
+        self.assertTrue(get_params(mocker)['invalidate'])
+        self.assertTrue(get_params(mocker)['overwrite'])
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_rename_supports_context(self, mocker):
         """Should support context"""
         mocker.return_value = MOCK_RESPONSE
 
         uploader.rename(TEST_IMAGE, TEST_IMAGE + "2", context=True)
-        args, kargs = mocker.call_args
-        self.assertTrue(get_params(args)['context'])
+        
+        self.assertTrue(get_params(mocker)['context'])
 
         uploader.rename(TEST_IMAGE, TEST_IMAGE + "2")
-        args, kargs = mocker.call_args
-        self.assertIsNone(get_params(args).get('context'))
+        
+        self.assertIsNone(get_params(mocker).get('context'))
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_rename_supports_metadata(self, mocker):
         """Should support metadata"""
         mocker.return_value = MOCK_RESPONSE
 
         uploader.rename(TEST_IMAGE, TEST_IMAGE + "2", metadata=True)
-        args, kargs = mocker.call_args
-        self.assertTrue(get_params(args)['metadata'])
+        
+        self.assertTrue(get_params(mocker)['metadata'])
 
         uploader.rename(TEST_IMAGE, TEST_IMAGE + "2")
-        args, kargs = mocker.call_args
-        self.assertIsNone(get_params(args).get('metadata'))
+        
+        self.assertIsNone(get_params(mocker).get('metadata'))
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_use_filename(self):
@@ -459,7 +460,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
             "public_ids": public_ids,
         })
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_clear_invalid(self, mocker):
         mocker.return_value = MOCK_RESPONSE
@@ -507,7 +508,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         uploader.upload(TEST_IMAGE, headers=["Link: 1"], tags=[UNIQUE_TAG])
         uploader.upload(TEST_IMAGE, headers={"Link": "1"}, tags=[UNIQUE_TAG])
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_extra_headers(self, mocker):
         """Should support extra headers"""
@@ -515,7 +516,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         uploader.upload(TEST_IMAGE, extra_headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
                                                                  'AppleWebKit/537.36 (KHTML, like Gecko) '
                                                                  'Chrome/58.0.3029.110 Safari/537.3'})
-        headers = get_headers(mocker.call_args[0])
+        headers = get_headers(mocker)
         self.assertEqual(headers.get('User-Agent'), 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' 
                                                     'AppleWebKit/537.36 (KHTML, like Gecko) '
                                                     'Chrome/58.0.3029.110 Safari/537.3')
@@ -527,7 +528,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         self.assertGreater(result["width"], 1)
         self.assertGreater(result["height"], 1)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_create_slideshow_from_manifest_transformation(self, mocker):
         """Should create slideshow from a manifest transformation"""
@@ -550,13 +551,13 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
 
         args, _ = mocker.call_args
 
-        self.assertTrue(get_uri(args).endswith('/video/create_slideshow'))
+        self.assertTrue(get_uri(mocker).endswith('/video/create_slideshow'))
 
-        self.assertEqual("fn_render:" + slideshow_manifest, get_params(args)['manifest_transformation'])
-        self.assertEqual("f_auto,q_auto", get_params(args)['transformation'])
-        self.assertEqual("tag1,tag2,tag3", get_params(args)['tags'])
+        self.assertEqual("fn_render:" + slideshow_manifest, get_params(mocker)['manifest_transformation'])
+        self.assertEqual("f_auto,q_auto", get_params(mocker)['transformation'])
+        self.assertEqual("tag1,tag2,tag3", get_params(mocker)['tags'])
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_create_slideshow_from_manifest_json(self, mocker):
         """Should create slideshow from a manifest json"""
@@ -596,11 +597,11 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
 
         args, _ = mocker.call_args
 
-        self.assertEqual(slideshow_manifest_json_str, get_params(args)["manifest_json"])
-        self.assertEqual("1", get_params(args)["overwrite"])
-        self.assertEqual(TEST_ID, get_params(args)["public_id"])
-        self.assertEqual(notification_url, get_params(args)["notification_url"])
-        self.assertEqual(API_TEST_PRESET, get_params(args)["upload_preset"])
+        self.assertEqual(slideshow_manifest_json_str, get_params(mocker)["manifest_json"])
+        self.assertEqual("1", get_params(mocker)["overwrite"])
+        self.assertEqual(TEST_ID, get_params(mocker)["public_id"])
+        self.assertEqual(notification_url, get_params(mocker)["notification_url"])
+        self.assertEqual(API_TEST_PRESET, get_params(mocker)["upload_preset"])
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_tags(self):
@@ -803,7 +804,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
             self.assertEqual(resource["width"], LARGE_FILE_WIDTH)
             self.assertEqual(resource["height"], LARGE_FILE_HEIGHT)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_upload_preset(self, mocker):
         """Should support unsigned uploading using presets """
@@ -811,15 +812,15 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
 
         uploader.unsigned_upload(TEST_IMAGE, API_TEST_PRESET)
 
-        args, kargs = mocker.call_args
+        
 
-        self.assertTrue(get_uri(args).endswith("/image/upload"))
+        self.assertTrue(get_uri(mocker).endswith("/image/upload"))
         self.assertEqual("POST", get_method(mocker))
         self.assertIsNotNone(get_param(mocker, "file"))
         self.assertIsNone(get_param(mocker, "signature"))
         self.assertEqual(get_param(mocker, "upload_preset"), API_TEST_PRESET)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_upload_preset_in_config(self, mocker):
         """Should support uploading using presets from config"""
@@ -827,14 +828,14 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         cloudinary.config().upload_preset = API_TEST_PRESET
         uploader.upload(TEST_IMAGE)
 
-        args, kargs = mocker.call_args
+        
 
-        self.assertTrue(get_uri(args).endswith("/image/upload"))
+        self.assertTrue(get_uri(mocker).endswith("/image/upload"))
         self.assertEqual("POST", get_method(mocker))
         self.assertIsNotNone(get_param(mocker, "file"))
         self.assertEqual(get_param(mocker, "upload_preset"), API_TEST_PRESET)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test1_upload_preset_in_config(self, mocker):
         """Should support overwriting upload presets in config"""
@@ -842,9 +843,9 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         cloudinary.config().upload_preset = API_TEST_PRESET
         uploader.upload(TEST_IMAGE, upload_preset=None)
 
-        args, kargs = mocker.call_args
+        
 
-        self.assertTrue(get_uri(args).endswith("/image/upload"))
+        self.assertTrue(get_uri(mocker).endswith("/image/upload"))
         self.assertEqual("POST", get_method(mocker))
         self.assertIsNotNone(get_param(mocker, "file"))
         self.assertEqual(get_param(mocker, "upload_preset"), None)
@@ -888,7 +889,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
                          "a_45")
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_access_control(self, request_mock):
         request_mock.return_value = MOCK_RESPONSE
 
@@ -899,7 +900,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         exp_acl = '[{"access_type":"anonymous","start":"2018-02-22 16:20:57 +0200","end":"2018-03-22 00:00 +0200"}]'
 
         uploader.upload(TEST_IMAGE, access_control=acl)
-        params = get_params(request_mock.call_args[0])
+        params = get_params(request_mock)
 
         self.assertIn("access_control", params)
         self.assertEqual(exp_acl, params["access_control"])
@@ -912,7 +913,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         exp_acl_2 = '[{"access_type":"anonymous","start":"2019-02-22T16:20:57","end":"2019-03-22T00:00:00+00:00"}]'
 
         uploader.upload(TEST_IMAGE, access_control=acl_2)
-        params = get_params(request_mock.call_args[0])
+        params = get_params(request_mock)
 
         self.assertEqual(exp_acl_2, params["access_control"])
 
@@ -921,7 +922,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         exp_acl_str = '[{"access_type":"anonymous","start":"2019-02-22 16:20:57 +0200","end":"2019-03-22 00:00 +0200"}]'
 
         uploader.upload(TEST_IMAGE, access_control=acl_str)
-        params = get_params(request_mock.call_args[0])
+        params = get_params(request_mock)
 
         self.assertEqual(exp_acl_str, params["access_control"])
 
@@ -931,7 +932,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         expected_list_of_acl = "[" + ",".join([v[1:-1] for v in (exp_acl, exp_acl_2, exp_acl_str)]) + "]"
 
         uploader.upload(TEST_IMAGE, access_control=list_of_acl)
-        params = get_params(request_mock.call_args[0])
+        params = get_params(request_mock)
 
         self.assertEqual(expected_list_of_acl, params["access_control"])
 
@@ -941,7 +942,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
             with self.assertRaises(ValueError):
                 uploader.upload(TEST_IMAGE, access_control=invalid_value)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     def test_various_upload_parameters(self, request_mock):
         """Should support various parameters in upload and explicit"""
         request_mock.return_value = MOCK_RESPONSE
@@ -956,13 +957,13 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
 
         uploader.upload(TEST_IMAGE, **options)
 
-        params = get_params(request_mock.call_args[0])
+        params = get_params(request_mock)
         for param in options.keys():
             self.assertIn(param, params)
 
         uploader.explicit(TEST_IMAGE, **options)
 
-        params = get_params(request_mock.call_args[0])
+        params = get_params(request_mock)
         for param in options.keys():
             self.assertIn(param, params)
 
@@ -1075,7 +1076,7 @@ P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC\
         self.assertIn("timestamp", parameters)
         self.assertIn("signature", parameters)
 
-    @patch('urllib3.request.RequestMethods.request')
+    @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
     def test_create_zip_with_target_asset_folder(self, mocker):
         """Should pass target_asset_folder parameter on archive generation"""


### PR DESCRIPTION
### Brief Summary of Changes
This PR adds compatibility with `urllib3` version `2.0`.

Fixes #355, #347 

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
