### PR TITLE
Add support for `use_fetch_format` parameter in video tag

### DIFF
--- a/cloudinary/__init__.py
+++ b/cloudinary/__init__.py
@@ -741,7 +741,11 @@ class CloudinaryResource(object):
         :return: Video tag
         """
         public_id = options.get('public_id', self.public_id)
-        source = re.sub(r"\.({0})$".format("|".join(self.default_source_types())), '', public_id)
+        use_fetch_format = options.get('use_fetch_format', config().use_fetch_format)
+        if not use_fetch_format:
+            source = re.sub(r"\.({0})$".format("|".join(self.default_source_types())), '', public_id)
+        else:
+            source = public_id
 
         custom_attributes = options.pop("attributes", dict())
 

--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -311,11 +311,13 @@ def patch_fetch_format(options):
     """
     When upload type is fetch, remove the format options.
     In addition, set the fetch_format options to the format value unless it was already set.
-    Mutates the options parameter!
+    Mutates the "options" parameter!
 
     :param options: URL and transformation options
     """
-    if options.get("type", "upload") != "fetch":
+    use_fetch_format = options.pop("use_fetch_format", cloudinary.config().use_fetch_format)
+
+    if options.get("type", "upload") != "fetch" and not use_fetch_format:
         return
 
     resource_format = options.pop("format", None)

--- a/test/test_video.py
+++ b/test/test_video.py
@@ -169,6 +169,20 @@ class VideoTest(unittest.TestCase):
             self.video.video(poster=expected_url.format('', 'jpg'), sources=self.video.default_video_sources)
         )
 
+    def test_video_tag_default_sources_use_fetch_format(self):
+        video = CloudinaryVideo("sample.mp4")
+        expected_url = VIDEO_UPLOAD_PATH + "f_{1},{0}/sample.mp4"
+
+        self.assertEqual(
+            "<video poster=\"" + VIDEO_UPLOAD_PATH + "f_jpg/sample.mp4" + "\">" +
+            "<source src=\"" + expected_url.format('vc_h265', 'mp4') + "\" type=\"video/mp4; codecs=hev1\">" +
+            "<source src=\"" + expected_url.format('vc_vp9', 'webm') + "\" type=\"video/webm; codecs=vp9\">" +
+            "<source src=\"" + expected_url.format('vc_auto', 'mp4') + "\" type=\"video/mp4\">" +
+            "<source src=\"" + expected_url.format('vc_auto', 'webm') + "\" type=\"video/webm\">" +
+            "</video>",
+            video.video(sources=self.video.default_video_sources, use_fetch_format=True)
+        )
+
     def test_video_tag_custom_sources(self):
         custom_sources = [
             {


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
