### PR TITLE
Add support for `delete_access_key` in Provisioning API

### DIFF
--- a/cloudinary/provisioning/__init__.py
+++ b/cloudinary/provisioning/__init__.py
@@ -3,4 +3,4 @@ from .account import (sub_accounts, create_sub_account, delete_sub_account, sub_
                       user_groups, create_user_group, update_user_group, delete_user_group, user_group,
                       add_user_to_group, remove_user_from_group, user_group_users, user_in_user_groups,
                       users, create_user, delete_user, user, update_user, access_keys, generate_access_key,
-                      update_access_key, Role)
+                      update_access_key, delete_access_key, Role)

--- a/cloudinary/provisioning/account.py
+++ b/cloudinary/provisioning/account.py
@@ -448,3 +448,29 @@ def update_access_key(sub_account_id, api_key, name=None, enabled=None, **option
         "enabled": enabled,
     }
     return _call_account_api("put", uri, params, **options)
+
+
+def delete_access_key(sub_account_id, api_key=None, name=None, **options):
+    """
+    Delete an existing access key by api_key or by name.
+
+    :param sub_account_id:      The id of the sub account.
+    :type sub_account_id:       str
+    :param api_key:             The API key of the access key.
+    :type api_key:              str|int
+    :param name:                The name of the access key.
+    :type name:                 str
+    :param options:             Generic advanced options dict, see online documentation.
+    :type options:              dict, optional
+    :return:                    Operation status.
+    :rtype:                     dict
+    """
+    uri = [SUB_ACCOUNTS_SUB_PATH, sub_account_id, ACCESS_KEYS]
+
+    if api_key is not None:
+        uri.append(str(api_key))
+
+    params = {
+        "name": name
+    }
+    return _call_account_api("delete", uri, params, **options)

--- a/test/test_provisioning_api.py
+++ b/test/test_provisioning_api.py
@@ -241,6 +241,26 @@ class AccountApiTest(unittest.TestCase):
         self.assertEqual(updated_key_name, res["name"])
         self.assertEqual(False, res["enabled"])
 
+    @unittest.skipUnless(cloudinary.provisioning.account_config().provisioning_api_secret,
+                         "requires provisioning_api_key/provisioning_api_secret")
+    def test_delete_access_key(self):
+        key_name = UNIQUE_TEST_ID + "_delete_key"
+        named_key_name = UNIQUE_TEST_ID + "_delete_by_name_key"
+
+        key_res = cloudinary.provisioning.generate_access_key(self.cloud_id, name=key_name, enabled=True)
+        self.assertEqual(key_name, key_res["name"])
+        self.assertEqual(True, key_res["enabled"])
+
+        named_key_res = cloudinary.provisioning.generate_access_key(self.cloud_id, name=named_key_name, enabled=True)
+        self.assertEqual(named_key_name, named_key_res["name"])
+        self.assertEqual(True, named_key_res["enabled"])
+
+        key_del_res = cloudinary.provisioning.delete_access_key(self.cloud_id, named_key_res["api_key"])
+        self.assertEqual("ok", key_del_res["message"])
+
+        named_key_del_res = cloudinary.provisioning.delete_access_key(self.cloud_id, name=key_name)
+        self.assertEqual("ok", named_key_del_res["message"])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
