### PR TITLE
Add support for `skip_backup` in `delete_folder` Admin API

### DIFF
--- a/cloudinary/api.py
+++ b/cloudinary/api.py
@@ -565,7 +565,9 @@ def delete_folder(path, **options):
 
     :rtype: Response
     """
-    return call_api("delete", ["folders", path], {}, **options)
+
+    params = only(options, "skip_backup")
+    return call_api("delete", ["folders", path], params, **options)
 
 
 def restore(public_ids, **options):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -988,10 +988,12 @@ class ApiTest(unittest.TestCase):
         """ should delete folder """
         mocker.return_value = MOCK_RESPONSE
 
-        api.delete_folder(UNIQUE_TEST_FOLDER)
+        api.delete_folder(UNIQUE_TEST_FOLDER, skip_backup=True)
 
         self.assertEqual("DELETE", get_method(mocker))
         self.assertTrue(get_uri(mocker).endswith('/folders/' + UNIQUE_TEST_FOLDER))
+        self.assertTrue("skip_backup" in get_params(mocker))
+        self.assertEqual("true", get_params(mocker)["skip_backup"])
 
     @patch(URLLIB3_REQUEST)
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")
@@ -1000,8 +1002,6 @@ class ApiTest(unittest.TestCase):
         mocker.return_value = MOCK_RESPONSE
 
         api.root_folders(next_cursor=NEXT_CURSOR, max_results=10)
-
-        args, kwargs = mocker.call_args
 
         self.assertTrue("next_cursor" in get_params(mocker))
         self.assertTrue("max_results" in get_params(mocker))


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
