### PR TITLE
Fix signature containing boolean values

### DIFF
--- a/cloudinary/utils.py
+++ b/cloudinary/utils.py
@@ -628,7 +628,11 @@ def sign_request(params, options):
 
 
 def api_sign_request(params_to_sign, api_secret, algorithm=SIGNATURE_SHA1):
-    params = [(k + "=" + (",".join(v) if isinstance(v, list) else str(v))) for k, v in params_to_sign.items() if v]
+    params = [(k + "=" + (
+        ",".join(v) if isinstance(v, list) else
+        str(v).lower() if isinstance(v, bool) else
+        str(v)
+    )) for k, v in params_to_sign.items() if v]
     to_sign = "&".join(sorted(params))
     return compute_hex_hash(to_sign + api_secret, algorithm)
 


### PR DESCRIPTION
True in python was converted to "True" in signature calculation. JSON serialisation however converted it to "true", which resulted in invalid signatures being calculated.

### Brief Summary of Changes
Signature calculation correctly handles boolean values.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [X] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
