### PR TITLE
Add support for `allow_dynamic_list_values` parameter in `MetadataField`

### DIFF
--- a/cloudinary/api.py
+++ b/cloudinary/api.py
@@ -741,7 +741,7 @@ def update_metadata_field(field_external_id, field, **options):
 
 def __metadata_field_params(field):
     return only(field, "type", "external_id", "label", "mandatory", "restrictions",
-                "default_value", "default_disabled", "validation", "datasource")
+                "default_value", "default_disabled", "validation", "datasource", "allow_dynamic_list_values")
 
 
 def delete_metadata_field(field_external_id, **options):

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -285,12 +285,14 @@ class MetadataTest(unittest.TestCase):
             "external_id": EXTERNAL_ID_SET,
             "label": EXTERNAL_ID_SET,
             "type": "set",
+            "allow_dynamic_list_values": True,
         })
 
         self.assert_metadata_field(result, "set", {
             "label": EXTERNAL_ID_SET,
             "external_id": EXTERNAL_ID_SET,
             "mandatory": False,
+            "allow_dynamic_list_values": True,
         })
 
     @unittest.skipUnless(cloudinary.config().api_secret, "requires api_key/api_secret")


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
